### PR TITLE
Custom complete widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Some variables:
 
 - `FZF_TAB_OPTS`: Its parameters
 
+- `FZF_TAB_INSERT_SPACE`: If set, fzf-tab will automatically appending a space after completion.
+
 - `FZF_TAB_QUERY`: Strategy for generating query strings:
 
     - `input`: just like zsh's default behavior

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -57,7 +57,7 @@ function compadd() {
 
 [[ ${FZF_TAB_INSERT_SPACE:='1'} ]]
 [[ ${FZF_TAB_COMMAND:='fzf'} ]]
-[[ ${FZF_TAB_OPTS:='--cycle --layout=reverse --tiebreak=begin --bind tab:down,ctrl-j:accept --height=50%'} ]]
+[[ ${FZF_TAB_OPTS:='--cycle --layout=reverse --tiebreak=begin --bind tab:down,ctrl-j:accept --height=15'} ]]
 (( $+FZF_TAB_QUERY )) || {
     FZF_TAB_QUERY=(prefix input first)
 }

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -161,11 +161,7 @@ function _fzf_tab_complete() {
     if [[ -n $choice ]] {
         local -A v=("${(@0)${compcap[$choice]}}")
         local -a args=("${(@ps:\1:)v[args]}")
-        if [[ -n $args[1] ]] {
-            IPREFIX=$v[IPREFIX] PREFIX=$v[PREFIX] SUFFIX=$v[SUFFIX] ISUFFIX=$v[ISUFFIX] builtin compadd "$args[@]" -Q -- $v[word]
-        } else {
-            IPREFIX=$v[IPREFIX] PREFIX=$v[PREFIX] SUFFIX=$v[SUFFIX] ISUFFIX=$v[ISUFFIX] builtin compadd -Q -- $v[word]
-        }
+        IPREFIX=$v[IPREFIX] PREFIX=$v[PREFIX] SUFFIX=$v[SUFFIX] ISUFFIX=$v[ISUFFIX] builtin compadd "${args[@]:-Q}" -Q -- $v[word]
         # the first result is '' (see the last line of compadd)
         compstate[insert]='2'${FZF_TAB_INSERT_SPACE:+' '}
     }

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -164,9 +164,12 @@ function _fzf_tab_complete() {
         } else {
             IPREFIX=$v[IPREFIX] PREFIX=$v[PREFIX] SUFFIX=$v[SUFFIX] ISUFFIX=$v[ISUFFIX] builtin compadd -Q -- $v[word]
         }
+        # the first result is '' (see the last line of compadd)
         compstate[insert]='2'${FZF_TAB_INSERT_SPACE:+' '}
-        compstate[list]=
+    } else {
+        compstate[insert]=
     }
+    compstate[list]=
 }
 
 zle -C _fzf_tab_complete complete-word _fzf_tab_complete


### PR DESCRIPTION
Use a complete widget, so that the final result can be inserted by the builtin completion system, so that fzf-tab doesn't need to deal with various suffixes by itself.

Fix #6
Fix #7
Fix #9