### PR TITLE
Minor stylistic improvements in parameter declarations

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -55,12 +55,10 @@ function compadd() {
     builtin compadd -Q -U ''
 }
 
-[[ ${FZF_TAB_INSERT_SPACE:='1'} ]]
-[[ ${FZF_TAB_COMMAND:='fzf'} ]]
-[[ ${FZF_TAB_OPTS:='--cycle --layout=reverse --tiebreak=begin --bind tab:down,ctrl-j:accept --height=15'} ]]
-(( $+FZF_TAB_QUERY )) || {
-    FZF_TAB_QUERY=(prefix input first)
-}
+: ${FZF_TAB_INSERT_SPACE:='1'}
+: ${FZF_TAB_COMMAND:='fzf'}
+: ${FZF_TAB_OPTS='--cycle --layout=reverse --tiebreak=begin --bind tab:down,ctrl-j:accept --height=15'}
+: ${(A)=FZF_TAB_QUERY=prefix input first}
 
 # select result, first line is query string
 function _fzf_tab_select() {


### PR DESCRIPTION
1. Use `: ${...}` instead of `[[ ${...} ]]` as this is the standard zsh idiom for discarding values of expansions performed for their side effects.
2. It's valid for `FZF_TAB_OPTS` to have empty value, so it shouldn't be replaced with the default.
3. Initialize `FZF_TAB_QUERY` the same way as other parameters for the sake of consistency.