### PR TITLE
bug fix: don't break user locale

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -232,7 +232,6 @@ _fzf_tab_get_candidates() {
     (( $#candidates == 0 )) && return
 
     (( same_word )) && candidates[2,-1]=()
-    local LC_ALL=C
     candidates=("${(@on)candidates}")
 
     # hide needless group


### PR DESCRIPTION
There is a bug in Zsh that causes `local LC_ALL=C` to leak outside of its scope. As a result, in some environments fzf-tab changes user locale.

It's not important for candidates to be sorted in byte order, and it's also arguably worse than respecting the order prescribed by the user locale. So I'm removing it.

I think it was I who added this `local LC_ALL=C` in an earlier PR. Sorry about that.