### PR TITLE
Support FZF custom completion API

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ Key Bindings:
 
 For example <kbd>Ctrl</kdb>+<kdb>T</kbd> `bindkey '^T' toggle-fzf-tab`
 
+### Custom completions
+
+There exists mechanism for overwriting completion action for particular command
+[similar to fzf](https://github.com/junegunn/fzf/wiki/Examples-(completion)).
+If function named `_fzf_complete_foo` is found, it will be used for handling completions
+of `foo` command.
+
+If you also have [fzf's completions](https://github.com/junegunn/fzf#fuzzy-completion-for-bash-and-zsh)
+enabled (`completion.zsh` is sourced), you can use it's `_fzf_complete` helper function, for example:
+```
+_fzf_complete_foo() {
+  _fzf_complete "--multi --reverse" "$@" < <(
+    echo foo
+    echo bar
+    echo bazz
+  )
+}
+```
+
 ### Configure
 
 Here are some variables which can be used to control the behavior of fzf-tab.
@@ -177,6 +196,16 @@ printc() {
 #### `FZF_TAB_CONTINUOUS_TRIGGER`
 
 The key trigger continuous completion. Default value: `/`
+
+#### FZF_TAB_CUSTOM_COMPLETIONS
+
+Whether to search for custom completion functions. Default value: `1`
+
+#### FZF_TAB_CUSTOM_COMPLETIONS_PREFIX
+
+Default value: `"_fzf_complete_"`
+
+note: The default value matches fzf name convention so that the same functions can be used both by fzf and fzf-tab.
 
 ## Difference from other plugins
 

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -85,6 +85,8 @@ _fzf_tab_remove_space() {
 : ${FZF_TAB_SHOW_GROUP:=full}
 : ${FZF_TAB_NO_GROUP_COLOR:=$'\033[37m'}
 : ${FZF_TAB_CONTINUOUS_TRIGGER:='/'}
+: ${FZF_TAB_CUSTOM_COMPLETIONS:='1'}
+: ${FZF_TAB_CUSTOM_COMPLETIONS_PREFIX:='_fzf_complete_'}
 : ${(A)=FZF_TAB_QUERY=prefix input first}
 : ${(A)=FZF_TAB_SINGLE_GROUP=color header}
 : ${(A)=FZF_TAB_GROUP_COLORS=\
@@ -95,7 +97,7 @@ _fzf_tab_remove_space() {
 
 (( $+FZF_TAB_OPTS )) || FZF_TAB_OPTS=(
     --ansi   # Enable ANSI color support, necessary for showing groups
-    --expect='$FZF_TAB_CONTINUOUS_TRIGGER' # For continuous completion 
+    --expect='$FZF_TAB_CONTINUOUS_TRIGGER' # For continuous completion
     '--color=hl:$(( $#headers == 0 ? 108 : 255 ))'
     --nth=2,3 --delimiter='\x00'  # Don't search FZF_TAB_PREFIX
     --layout=reverse --height=75%
@@ -306,7 +308,24 @@ _fzf_tab_complete() {
 
 zle -C _fzf_tab_complete complete-word _fzf_tab_complete
 
+_fzf_tab_try_custom_completion() {
+    # do not steal fzf's completions
+    [[ $LBUFFER =~ ${(q)FZF_COMPLETION_TRIGGER-'**'}$ ]] && return 1
+    local tokens=(${(z)LBUFFER})
+    [[ ${LBUFFER[-1]} = ' ' ]] && tokens+=("")
+    local cmd=${tokens[1]}
+    if (( $+functions[${FZF_TAB_CUSTOM_COMPLETIONS_PREFIX}${cmd}] )); then
+        local prefix=${tokens[-1]}
+        local lbuf
+        [ -z "${tokens[-1]}" ] && lbuf=$LBUFFER || lbuf=${LBUFFER:0:-${#tokens[-1]}}
+        prefix="$prefix" eval _fzf_complete_${cmd} ${(q)lbuf}
+        return 0
+    fi
+    return 1
+}
+
 fzf-tab-complete() {
+    (( FZF_TAB_CUSTOM_COMPLETIONS )) && _fzf_tab_try_custom_completion && return
     # complete or not complete, this is a question
     # this name must be ugly to avoid clashes
     local -i _fzf_tab_continue=1 _fzf_tab_should_complete=0


### PR DESCRIPTION
API explained [here](https://github.com/junegunn/fzf/wiki/Examples-(completion)), handy way of defining custom completions for particular commands.
Copied some functions from fzf [`completions.zsh`](https://github.com/junegunn/fzf/blob/master/shell/completion.zsh) to allow not sourcing it.