### PR TITLE
More configuration via zstyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Replace zsh's default completion selection menu with fzf!
         - [single-group](#single-group)
         - [group-colors](#group-colors)
         - [show-group](#show-group)
-        - [sort](#sort)
 - [Difference from other plugins](#difference-from-other-plugins)
 - [Compatibility with other plugins](#compatibility-with-other-plugins)
 - [Related projects](#related-projects)
@@ -95,7 +94,7 @@ Now it use zstyle, because zstyle can give you more control over fzf-tab's behav
 
 ```zsh
 # disable sort when completing options of any command
-zstyle ':fzf-tab:complete:*:options' sort false
+zstyle ':completion:complete:*:options' sort false
 
 # use input as query string when completing zlua
 zstyle ':fzf-tab:complete:_zlua:*' query-string input
@@ -106,9 +105,8 @@ zstyle ':fzf-tab:complete:kill:argument-rest' extra-opts '--preview=echo {}' --p
 
 # (experientment) give a preview of directory when compleing cd
 local extract="
-# remove some hidden characters
-in={}
-in=\${\${in%\$'\2'*}#*\$'\2'}
+# trim input
+in=\${\${\"\$(<{+f})\"%\$'\0'*}#*\$'\0'}
 # get ctxt for current completion
 local -A ctxt=(\"\${(@ps:\2:)CTXT}\")
 "
@@ -144,7 +142,7 @@ FZF_TAB_COMMAND=(
     --ansi   # Enable ANSI color support, necessary for showing groups
     --expect='$continuous_trigger' # For continuous completion
     '--color=hl:$(( $#headers == 0 ? 108 : 255 ))'
-    --nth=2,3 --delimiter='\x02'  # Don't search FZF_TAB_PREFIX
+    --nth=2,3 --delimiter='\x00'  # Don't search prefix
     --layout=reverse --height='${FZF_TMUX_HEIGHT:=75%}'
     --tiebreak=begin -m --bind=tab:down,ctrl-j:accept,change:top,ctrl-space:toggle --cycle
     '--query=$query'   # $query will be expanded to query string at runtime.
@@ -265,12 +263,6 @@ When `zstyle ':completion:*:descriptions' format` is set, fzf-tab will display t
 Set to `full` to show all descriptions, set to `brief` to only show descriptions for groups with duplicate members.
 
 Default value: `zstyle ':fzf-tab:*' show-group full`
-
-### sort
-
-Whether sort the result.
-
-Default value: `zstyle ':fzf-tab:*' sort true`
 
 # Difference from other plugins
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ zstyle ':fzf_tab:complete:_zlua:*' query-string input
 # give a preview when completing `kill`
 zstyle ':completion:*:*:*:*:processes' command "ps -u $USER -o pid,user,comm,cmd -w -w"
 zstyle ':fzf_tab:complete:kill:argument-rest' extra-opts '--preview=echo {}' --preview-window=down:3:wrap
+
+# (experientment) give a preview of directory when compleing cd
+local extract="
+# remove some hidden characters
+in={}
+in=\${\${in%\$'\2'*}#*\$'\2'}
+# get ctxt for current completion
+local -A ctxt=(\"\${(@ps:\2:)CTXT}\")
+"
+zstyle ':fzf_tab:complete:cd*' extra-opts --preview=$extract"exa -1 --color=always \${~ctxt[hpre]}\$in"
 ```
 
 zstyle is set via command like this: `zstyle ':fzf_tab:{context}' tag value`.

--- a/README.md
+++ b/README.md
@@ -95,14 +95,14 @@ Now it use zstyle, because zstyle can give you more control over fzf-tab's behav
 
 ```zsh
 # disable sort when completing options of any command
-zstyle ':fzf_tab:complete:*:options' sort false
+zstyle ':fzf-tab:complete:*:options' sort false
 
 # use input as query string when completing zlua
-zstyle ':fzf_tab:complete:_zlua:*' query-string input
+zstyle ':fzf-tab:complete:_zlua:*' query-string input
 
 # give a preview when completing `kill`
 zstyle ':completion:*:*:*:*:processes' command "ps -u $USER -o pid,user,comm,cmd -w -w"
-zstyle ':fzf_tab:complete:kill:argument-rest' extra-opts '--preview=echo {}' --preview-window=down:3:wrap
+zstyle ':fzf-tab:complete:kill:argument-rest' extra-opts '--preview=echo {}' --preview-window=down:3:wrap
 
 # (experientment) give a preview of directory when compleing cd
 local extract="
@@ -112,10 +112,10 @@ in=\${\${in%\$'\2'*}#*\$'\2'}
 # get ctxt for current completion
 local -A ctxt=(\"\${(@ps:\2:)CTXT}\")
 "
-zstyle ':fzf_tab:complete:cd*' extra-opts --preview=$extract"exa -1 --color=always \${~ctxt[hpre]}\$in"
+zstyle ':fzf-tab:complete:cd*' extra-opts --preview=$extract"exa -1 --color=always \${~ctxt[hpre]}\$in"
 ```
 
-zstyle is set via command like this: `zstyle ':fzf_tab:{context}' tag value`.
+zstyle is set via command like this: `zstyle ':fzf-tab:{context}' tag value`.
 See [zsh's doc](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fzutil-Module) for more information.
 
 You can use <kbd>C-x h</kbd> to get possible context for a command:
@@ -150,7 +150,7 @@ FZF_TAB_COMMAND=(
     '--query=$query'   # $query will be expanded to query string at runtime.
     '--header-lines=$#headers' # $#headers will be expanded to lines of headers at runtime
 )
-zstyle ':fzf_tab:*' command $FZF_TAB_COMMAND
+zstyle ':fzf-tab:*' command $FZF_TAB_COMMAND
 ```
 
 ### extra-opts
@@ -163,7 +163,7 @@ Default value: None
 
 The key to trigger a continuous completion. It's useful when complete a long path.
 
-Default value: `zstyle ':fzf_tab:*' continuous-trigger '/'`
+Default value: `zstyle ':fzf-tab:*' continuous-trigger '/'`
 
 ### fake-compadd
 
@@ -173,13 +173,13 @@ How to do a fake compadd. This only affects the result of multiple selections.
 - `fakeadd`: Try to deceive the completion system. Sometimes it fails and then leads to unwanted results.
 (eg. `sudo git \t` will get not only git subcommands but also local files)
 
-Default value: `zstyle ':fzf_tab:*' fake-compadd default`
+Default value: `zstyle ':fzf-tab:*' fake-compadd default`
 
 ### insert-space
 
 Whether to automatically insert a space after the result.
 
-Default value: `zstyle ':fzf_tab:*' insert-space true`
+Default value: `zstyle ':fzf-tab:*' insert-space true`
 
 ### query-string
 
@@ -192,13 +192,13 @@ Possible values:
 - `first`: just a flag. If set, the first valid query string will be used
 - `longest`: another flag. If set, the longest valid query string will be used
 
-Default value: `zstyle ':fzf_tab:*' query-string prefix input first`
+Default value: `zstyle ':fzf-tab:*' query-string prefix input first`
 
 ### prefix
 
 A prefix to indicate the color.
 
-Default value: `zstyle ':fzf_tab:*:' prefix '·'`
+Default value: `zstyle ':fzf-tab:*:' prefix '·'`
 
 **NOTE:** If not set `zstyle ':completion:*:descriptions' format`, it will be set to empty.
 
@@ -206,7 +206,7 @@ Default value: `zstyle ':fzf_tab:*:' prefix '·'`
 
 Color when there is no group.
 
-Default value: `zstyle ':fzf_tab:*' $'\033[37m'` (white)
+Default value: `zstyle ':fzf-tab:*' $'\033[37m'` (white)
 
 ### single-group
 
@@ -218,7 +218,7 @@ Possible values:
 - `color`: show group color
 - `header`: show group header
 
-Default value: `zstyle ':fzf_tab:*' single-group color header`
+Default value: `zstyle ':fzf-tab:*' single-group color header`
 
 ### group-colors
 
@@ -232,7 +232,7 @@ FZF_TAB_GROUP_COLORS=(
     $'\033[38;5;100m' $'\033[38;5;98m' $'\033[91m' $'\033[38;5;80m' $'\033[92m' \
     $'\033[38;5;214m' $'\033[38;5;165m' $'\033[38;5;124m' $'\033[38;5;120m'
 )
-zstyle ':fzf_tab:*' group-colors $FZF_TAB_GROUP_COLORS
+zstyle ':fzf-tab:*' group-colors $FZF_TAB_GROUP_COLORS
 ```
 
 To choose the color you want, you can first use this function to print the palette:
@@ -264,13 +264,13 @@ When `zstyle ':completion:*:descriptions' format` is set, fzf-tab will display t
 
 Set to `full` to show all descriptions, set to `brief` to only show descriptions for groups with duplicate members.
 
-Default value: `zstyle ':fzf_tab:*' show-group full`
+Default value: `zstyle ':fzf-tab:*' show-group full`
 
 ### sort
 
 Whether sort the result.
 
-Default value: `zstyle ':fzf_tab:*' sort true`
+Default value: `zstyle ':fzf-tab:*' sort true`
 
 # Difference from other plugins
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Replace zsh's default completion selection menu with fzf!
 - [Install](#install)
     - [Manual](#manual)
     - [Antigen](#antigen)
-    - [Zplugin](#zplugin)
+    - [Zinit](#zinit)
     - [Oh-My-Zsh](#oh-my-zsh)
 - [Usage](#usage)
     - [Configure](#configure)
@@ -54,10 +54,10 @@ source ~/somewhere/fzf-tab.plugin.zsh
 antigen bundle Aloxaf/fzf-tab
 ```
 
-## Zplugin
+## Zinit
 
 ```zsh
-zplugin light Aloxaf/fzf-tab
+zinit light Aloxaf/fzf-tab
 ```
 
 ## Oh-My-Zsh
@@ -89,8 +89,7 @@ For example <kbd>Ctrl</kdb>+<kdb>T</kbd> `bindkey '^T' toggle-fzf-tab`
 
 ## Configure
 
-fzf-tab used to use global variables for configuration. 
-Now it use zstyle, because zstyle can give you more control over fzf-tab's behavior, eg:
+fzf-tab use zstyle for configuration. It can give you more control over fzf-tab's behavior, eg:
 
 ```zsh
 # disable sort when completing options of any command
@@ -101,23 +100,24 @@ zstyle ':fzf-tab:complete:_zlua:*' query-string input
 
 # give a preview when completing `kill`
 zstyle ':completion:*:*:*:*:processes' command "ps -u $USER -o pid,user,comm,cmd -w -w"
-zstyle ':fzf-tab:complete:kill:argument-rest' extra-opts '--preview=echo {}' --preview-window=down:3:wrap
+zstyle ':fzf-tab:complete:kill:argument-rest' extra-opts '--preview=echo $(<{f})' --preview-window=down:3:wrap
 
-# (experientment) give a preview of directory when compleing cd
+# (experimental) give a preview of directory when completing cd
 local extract="
 # trim input
-in=\${\${\"\$(<{+f})\"%\$'\0'*}#*\$'\0'}
+in=\${\${\"\$(<{f})\"%\$'\0'*}#*\$'\0'}
 # get ctxt for current completion
 local -A ctxt=(\"\${(@ps:\2:)CTXT}\")
 "
 zstyle ':fzf-tab:complete:cd*' extra-opts --preview=$extract"exa -1 --color=always \${~ctxt[hpre]}\$in"
 ```
 
-zstyle is set via command like this: `zstyle ':fzf-tab:{context}' tag value`.
+fzf-tab is configured via command like this: `zstyle ':fzf-tab:{context}' tag value`. `fzf-tab` is the top context.
 See [zsh's doc](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fzutil-Module) for more information.
 
 You can use <kbd>C-x h</kbd> to get possible context for a command:
-Note: This command will break fzf-tab totally, you need to restart zsh to re-enable fzf-tab.
+
+**NOTE:** This command will break fzf-tab totally, you need to restart zsh to re-enable fzf-tab.
 
 ```zsh
 ❯ rg -- # Press `C-x h` here
@@ -129,7 +129,7 @@ tags in context :completion::files-enhance:::
     globbed-files  (_files _files_enhance)
 ```
 
-Here are avaiable tags:
+Here are avaiable tags in `fzf-tab` context:
 
 ### command
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Replace zsh's default completion selection menu with fzf!
 
 [![asciicast](https://asciinema.org/a/293849.svg)](https://asciinema.org/a/293849)
 
-## Install
+# Install
 
-### Manual
+## Manual
 
 First, clone this repository
 
@@ -20,19 +20,19 @@ Then add the following line to your `~/.zshrc`
 source ~/somewhere/fzf-tab.plugin.zsh
 ```
 
-### Antigen
+## Antigen
 
 ```zsh
 antigen bundle Aloxaf/fzf-tab
 ```
 
-### Zplugin
+## Zplugin
 
 ```zsh
 zplugin light Aloxaf/fzf-tab
 ```
 
-### Oh-My-Zsh
+## Oh-My-Zsh
 
 Clone this repository to your custom directory and then add `fzf-tab` to your plugin list.
 
@@ -40,7 +40,7 @@ Clone this repository to your custom directory and then add `fzf-tab` to your pl
 git clone https://github.com/Aloxaf/fzf-tab ~ZSH_CUSTOM/plugins/fzf-tab
 ```
 
-## Usage
+# Usage
 
 Just press <kbd>Tab</kbd> as usual~
 
@@ -59,7 +59,7 @@ Key Bindings:
 
 For example <kbd>Ctrl</kdb>+<kdb>T</kbd> `bindkey '^T' toggle-fzf-tab`
 
-### Custom completions
+## Custom completions
 
 There exists mechanism for overwriting completion action for particular command
 [similar to fzf](https://github.com/junegunn/fzf/wiki/Examples-(completion)).
@@ -79,7 +79,9 @@ _fzf_complete_foo() {
 }
 ```
 
-### Configure
+## Configure
+
+### Variables
 
 Here are some variables which can be used to control the behavior of fzf-tab.
 
@@ -105,37 +107,6 @@ FZF_TAB_OPTS=(
     '--header-lines=$#headers' # $#headers will be expanded to lines of headers at runtime
 )
 ```
-
-#### `FZF_TAB_INSERT_SPACE`
-
-Whether to automatically insert a space after the result, default value: `1`
-
-#### `FZF_TAB_QUERY`
-
-The strategy for generating query string, default value: `(prefix input first)`
-
-Possible values:
-
-- `input`: use user's input as query string, just like zsh's default behavior
-- `prefix`: use the longest common prefix for all candidates as the query string
-- `first`: just a flag. If set, the first valid query string will be used
-- `longest`: another flag. If set, the longest valid query string will be used
-
-#### `FZF_TAB_FAKE_COMPADD`
-
-How to do a fake compadd. This variable only affects the result of multiple selections.
-
-- `default`: Call compadd with an empty string. It will sometimes add extra whitespace if you select multiple results.
-- `fakeadd`: Try to deceive the completion system. Sometimes it fails and then leads to unwanted results.
-(eg. `sudo git \t` will get not only git subcommands but also local files)
-
-#### `FZF_TAB_SHOW_GROUP`
-
-When `zstyle ':completion:*:descriptions' format` is set, fzf-tab will display these group descriptions as headers.
-
-Set to `full` to show all descriptions, set to `brief` to only show descriptions for groups with duplicate members.
-
-Default value: full
 
 #### `FZF_TAB_PREFIX`
 
@@ -194,28 +165,103 @@ printc() {
 }
 ```
 
-#### `FZF_TAB_CONTINUOUS_TRIGGER`
-
-The key trigger continuous completion. Default value: `/`
-
-#### FZF_TAB_CUSTOM_COMPLETIONS
+#### `FZF_TAB_CUSTOM_COMPLETIONS`
 
 Whether to search for custom completion functions. Default value: `1`
 
-#### FZF_TAB_CUSTOM_COMPLETIONS_PREFIX
+#### `FZF_TAB_CUSTOM_COMPLETIONS_PREFIX`
 
 Default value: `"_fzf_complete_"`
 
 note: The default value matches fzf name convention so that the same functions can be used both by fzf and fzf-tab.
 
-## Difference from other plugins
+### Zstyle
+
+zstyle can give you more control over fzf-tab's behavior, eg:
+
+```
+# disable sort when completing options of any command
+zstyle ':fzf_tab:complete:*:options' sort false
+
+# use input as query string when completing zlua
+zstyle ':fzf_tab:complete:_zlua:*' query-string input
+```
+
+zstyle is set via command like this: `zstyle ':fzf_tab:{context}' tag value`.
+See [zsh's doc](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fzutil-Module) for more information.
+
+You can use <kbd>C-x h</kbd> to get possible context for a command:
+Note: This command will break fzf-tab totally, you need to restart zsh to re-enable fzf-tab.
+
+```zsh
+❯ rg -- # Press `C-x h` here
+tags in context :completion::complete:rg::
+    operand-argument-1 options  (_arguments _rg _ripgrep)
+tags in context :completion::complete:rg:options:
+    options  (_arguments _rg _ripgrep)
+tags in context :completion::files-enhance:::
+    globbed-files  (_files _files_enhance)
+```
+
+Here are avaiable tags:
+
+#### continuous-trigger
+
+The key to trigger a continuous completion. It's useful when complete a long path.
+
+Default value: `zstyle ':fzf_tab:*' continuous-trigger '/'`
+
+#### fake-compadd
+
+How to do a fake compadd. This only affects the result of multiple selections.
+
+- `default`: Call compadd with an empty string. It will sometimes add extra whitespace if you select multiple results.
+- `fakeadd`: Try to deceive the completion system. Sometimes it fails and then leads to unwanted results.
+(eg. `sudo git \t` will get not only git subcommands but also local files)
+
+Default value: `zstyle ':fzf_tab:*' fake-compadd default`
+
+#### insert-space
+
+Whether to automatically insert a space after the result.
+
+Default value: `zstyle ':fzf_tab:*' insert-space true`
+
+#### query-string
+
+The strategy for generating query string.
+
+Possible values:
+
+- `input`: use user's input as query string, just like zsh's default behavior
+- `prefix`: use the longest common prefix for all candidates as the query string
+- `first`: just a flag. If set, the first valid query string will be used
+- `longest`: another flag. If set, the longest valid query string will be used
+
+Default value: `zstyle ':fzf_tab:*' query-string prefix input first`
+
+#### show-group
+
+When `zstyle ':completion:*:descriptions' format` is set, fzf-tab will display these group descriptions as headers.
+
+Set to `full` to show all descriptions, set to `brief` to only show descriptions for groups with duplicate members.
+
+Default value: `zstyle ':fzf_tab:*' show-group full`
+
+#### sort
+
+Whether sort the result.
+
+Default value: `zstyle ':fzf_tab:*' sort true`
+
+# Difference from other plugins
 
 fzf-tab doesn't do "complete", it just shows your results of the default completion system.
 
 So it works EVERYWHERE (variables, function names, directory stack, in-word completion, etc.).
 And most of your configure for default completion system is still valid.
 
-## Compatibility with other plugins
+# Compatibility with other plugins
 
 Some plugins may also bind "^I" to their custom widget, like [fzf/shell/completion.zsh](https://github.com/junegunn/fzf/blob/master/shell/completion.zsh) or [ohmyzsh/lib/completion.zsh](https://github.com/ohmyzsh/ohmyzsh/blob/master/lib/completion.zsh#L61-L73).
 
@@ -223,6 +269,6 @@ By default, fzf-tab will call the widget previously bound to "^I" to get the com
 
 So if you find your fzf-tab doesn't work properly, please make sure it is the last plugin to bind "^I" (If you don't know what I mean, just put it to the end of your plugin list).
 
-## Related projects
+# Related projects
 
 - https://github.com/lincheney/fzf-tab-completion (fzf tab completion for zsh, bash and GNU readline apps)

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -33,7 +33,7 @@ compadd() {
     fi
 
     # store $curcontext for furthur usage
-    _fzf_tab_curcontext=:fzf_tab:${curcontext#:}
+    _fzf_tab_curcontext=:fzf-tab:${curcontext#:}
 
     # keep order of group description
     [[ -n $expl ]] && _fzf_tab_groups+=$expl
@@ -103,8 +103,8 @@ FZF_TAB_OPTS=(
 )
 
 _fzf_tab_add_default() {
-    zstyle -t ':fzf_tab:*' $1
-    (( $? != 2 )) || zstyle ':fzf_tab:*' $1 ${@:2}
+    zstyle -t ':fzf-tab:*' $1
+    (( $? != 2 )) || zstyle ':fzf-tab:*' $1 ${@:2}
 }
 
 _fzf_tab_get() {

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -32,6 +32,9 @@ compadd() {
         return
     fi
 
+    # store $curcontext for furthur usage
+    _fzf_tab_curcontext=${curcontext/:[^:]#:/:fzf_tab:}
+
     # keep order of group description
     [[ -n $expl ]] && _fzf_tab_groups+=$expl
 
@@ -53,7 +56,8 @@ compadd() {
 
     # dscr - the string to show to users
     # word - the string to be inserted
-    local dscr word i
+    local dscr word i sort cnt=$#_fzf_tab_compcap
+    zstyle -b "$_fzf_tab_curcontext" sort sort
     for i in {1..$#__hits}; do
         word=$__hits[i] && dscr=$__dscr[i]
         if [[ -n $dscr ]]; then
@@ -63,13 +67,16 @@ compadd() {
         else
             continue
         fi
+        [[ $sort == "yes" ]] || dscr=$((i + cnt))$'\b'$dscr
         _fzf_tab_compcap[$dscr]=$__tmp_value${word:+$'\0word\0'$word}
     done
+
     # tell zsh that the match is successful
-    case $FZF_TAB_FAKE_COMPADD in
-        fakeadd) nm=-1 ;;  # see _alternative:76
-        *) builtin compadd -U -qS '' -R _fzf_tab_remove_space '' ;;
-    esac
+    if zstyle -t "$_fzf_tab_curcontext" fake_compadd "fakeadd"; then
+        nm=-1  # see _alternative:76
+    else
+        builtin compadd -U -qS '' -R _fzf_tab_remove_space ''
+    fi
 }
 
 # when insert multi results, a whitespace will be added to each result
@@ -79,13 +86,8 @@ _fzf_tab_remove_space() {
     [[ $LBUFFER[-1] == ' ' ]] && LBUFFER[-1]=''
 }
 
-: ${FZF_TAB_INSERT_SPACE:='1'}
-: ${FZF_TAB_FAKE_COMPADD:='default'}
 : ${FZF_TAB_COMMAND:='fzf'}
-: ${FZF_TAB_SHOW_GROUP:=full}
 : ${FZF_TAB_NO_GROUP_COLOR:=$'\033[37m'}
-: ${FZF_TAB_CONTINUOUS_TRIGGER:='/'}
-: ${(A)=FZF_TAB_QUERY=prefix input first}
 : ${(A)=FZF_TAB_SINGLE_GROUP=color header}
 : ${(A)=FZF_TAB_GROUP_COLORS=\
     $'\033[94m' $'\033[32m' $'\033[33m' $'\033[35m' $'\033[31m' $'\033[38;5;27m' $'\033[36m' \
@@ -93,9 +95,17 @@ _fzf_tab_remove_space() {
     $'\033[38;5;214m' $'\033[38;5;165m' $'\033[38;5;124m' $'\033[38;5;120m'
 }
 
+# Some users may still use variable
+zstyle ':fzf_tab:*' continuous-trigger ${FZF_TAB_CONTINUOUS_TRIGGER:-'/'}
+zstyle ':fzf_tab:*' fake-compadd ${FZF_TAB_FAKE_COMPADD:-default}
+zstyle ':fzf_tab:*' insert-space ${FZF_TAB_INSERT_SPACE:-true}
+zstyle ':fzf_tab:*' query-string ${(A)=FZF_TAB_QUERY:-prefix input first}
+zstyle ':fzf_tab:*' show-group ${FZF_TAB_SHOW_GROUP:-full}
+zstyle ':fzf_tab:*' sort true
+
 (( $+FZF_TAB_OPTS )) || FZF_TAB_OPTS=(
     --ansi   # Enable ANSI color support, necessary for showing groups
-    --expect='$FZF_TAB_CONTINUOUS_TRIGGER' # For continuous completion 
+    --expect='$continuous_trigger' # For continuous completion 
     '--color=hl:$(( $#headers == 0 ? 108 : 255 ))'
     --nth=2,3 --delimiter='\x00'  # Don't search FZF_TAB_PREFIX
     --layout=reverse --height='${FZF_TMUX_HEIGHT:=75%}'
@@ -112,9 +122,10 @@ fi
 
 # sets `query` to the valid query string
 _fzf_tab_find_query_str() {
-    local key qtype tmp
+    local key qtype tmp query_string
     typeset -g query=
-    for qtype in $FZF_TAB_QUERY; do
+    zstyle -a "$_fzf_tab_curcontext" query_string query_string
+    for qtype in $query_string; do
         if [[ $qtype == prefix ]]; then
             # find the longest common prefix among ${(k)_fzf_tab_compcap}
             local -a keys=(${(k)_fzf_tab_compcap})
@@ -139,7 +150,7 @@ _fzf_tab_find_query_str() {
             fi
             tmp=${${tmp#$v[hpre]}#$v[apre]}
         fi
-        if (( $FZF_TAB_QUERY[(I)longest] )); then
+        if (( $query_string[(I)longest] )); then
             (( $#tmp > $#query )) && query=$tmp
         elif [[ -n $tmp ]]; then
             query=$tmp && break
@@ -184,7 +195,8 @@ _fzf_tab_get_headers() {
 
 # pupulates array `candidates` with completion candidates
 _fzf_tab_get_candidates() {
-    local dsuf k _v filepath first_word
+    setopt localoptions extendedglob
+    local dsuf k _v filepath first_word show_group
     local -i same_word=1
     local -Ua duplicate_groups=()
     local -A word_map=()
@@ -194,6 +206,8 @@ _fzf_tab_get_candidates() {
         (( $FZF_TAB_SINGLE_GROUP[(I)prefix] )) || local FZF_TAB_PREFIX=''
         (( $FZF_TAB_SINGLE_GROUP[(I)color] )) || local FZF_TAB_GROUP_COLORS=($FZF_TAB_NO_GROUP_COLOR)
     fi
+
+    zstyle -s "$_fzf_tab_curcontext" show_group show_group
 
     for k _v in ${(kv)_fzf_tab_compcap}; do
         local -A v=("${(@0)_v}")
@@ -214,14 +228,13 @@ _fzf_tab_get_candidates() {
         if (( $+v[group] )); then
             local color=$FZF_TAB_GROUP_COLORS[$v[group]]
             # add a hidden group index at start of string to keep group order when sorting
-            # FIXME: only support 16 groups
-            candidates+=$(([##16]$v[group]-1))$'\b'$color$FZF_TAB_PREFIX$'\0'$k$'\0'$dsuf$'\033[00m'
+            candidates+=$v[group]$'\b'$color$FZF_TAB_PREFIX$'\0'$k$'\0'$dsuf$'\033[00m'
         else
             candidates+=$FZF_TAB_SINGLE_COLOR$FZF_TAB_PREFIX$'\0'$k$'\0'$dsuf$'\033[00m'
         fi
 
         # check group with duplicate member
-        if [[ $FZF_TAB_SHOW_GROUP == brief ]]; then
+        if [[ $show_group == brief ]]; then
             if (( $+word_map[$v[word]] && $+v[group] )); then
                 duplicate_groups+=$v[group]            # add this group
                 duplicate_groups+=$word_map[$v[word]]  # add previous group
@@ -232,10 +245,12 @@ _fzf_tab_get_candidates() {
     (( $#candidates == 0 )) && return
 
     (( same_word )) && candidates[2,-1]=()
+    # sort and remove sort group or other index
     candidates=("${(@on)candidates}")
+    candidates=(${(@)candidates//[0-9]#$'\b'})
 
     # hide needless group
-    if [[ $FZF_TAB_SHOW_GROUP == brief ]]; then
+    if [[ $show_group == brief ]]; then
         local i indexs=({1..$#_fzf_tab_groups})
         for i in ${indexs:|duplicate_groups}; do
             # NOTE: _fzf_tab_groups is unique array
@@ -247,7 +262,7 @@ _fzf_tab_get_candidates() {
 _fzf_tab_complete() {
     local -A _fzf_tab_compcap
     local -Ua _fzf_tab_groups
-    local choice choices
+    local choice choices _fzf_tab_curcontext continuous_trigger
 
     IN_FZF_TAB=1
     _main_complete  # must run with user options; don't move `emulate -L zsh` above this line
@@ -264,6 +279,8 @@ _fzf_tab_complete() {
         *)
             _fzf_tab_find_query_str  # sets `query`
             _fzf_tab_get_headers     # sets `headers`
+            # sets continuous_trigger
+            zstyle -s "$_fzf_tab_curcontext" continuous-trigger continuous_trigger 
 
             [[ ${(t)FZF_TAB_OPTS} != *"array"* ]] && FZF_TAB_OPTS=(${(z)FZF_TAB_OPTS})
             local -a command=($FZF_TAB_COMMAND $FZF_TAB_OPTS)
@@ -277,7 +294,7 @@ _fzf_tab_complete() {
             ;;
     esac
 
-    if [[ $choices[1] == $FZF_TAB_CONTINUOUS_TRIGGER ]]; then
+    if [[ $choices[1] == $continuous_trigger ]]; then
         typeset -gi _fzf_tab_continue=1
         choices[1]=()
     fi
@@ -293,12 +310,13 @@ _fzf_tab_complete() {
     compstate[list]=
     compstate[insert]=
     if (( $#choices == 1 )); then
-        if [[ $FZF_TAB_FAKE_COMPADD == "fakeadd" ]]; then
+        if zstyle -t "$_fzf_tab_curcontext" fake-compadd "fakeadd"; then
             compstate[insert]='1'
         else
             compstate[insert]='2'
         fi
-        (( ! FZF_TAB_INSERT_SPACE )) || [[ $RBUFFER == ' '* ]] || compstate[insert]+=' '
+        zstyle -t "$_fzf_tab_curcontext" insert-space
+        (( $? )) || [[ $RBUFFER == ' '* ]] || compstate[insert]+=' '
     elif (( $#choice > 1 )); then
         compstate[insert]='all'
     fi

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -300,6 +300,10 @@ _fzf_tab_complete() {
     fi
 
     for choice in $choices; do
+        # if disale sort
+        for i in ${(k)_fzf_tab_compcap}; do
+            [[ $i != *$choice ]] || { choice=$i; break }
+        done
         local -A v=("${(@0)${_fzf_tab_compcap[$choice]}}")
         local -a args=("${(@ps:\1:)v[args]}")
         [[ -z $args[1] ]] && args=()  # don't pass an empty string

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -124,7 +124,7 @@ fi
 _fzf_tab_find_query_str() {
     local key qtype tmp query_string
     typeset -g query=
-    zstyle -a "$_fzf_tab_curcontext" query_string query_string
+    zstyle -a "$_fzf_tab_curcontext" query-string query_string
     for qtype in $query_string; do
         if [[ $qtype == prefix ]]; then
             # find the longest common prefix among ${(k)_fzf_tab_compcap}

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -33,7 +33,7 @@ compadd() {
     fi
 
     # store $curcontext for furthur usage
-    _fzf_tab_curcontext=:fzf-tab:${curcontext#:}
+    _fzf_tab_curcontext=${curcontext#:}
 
     # keep order of group description
     [[ -n $expl ]] && _fzf_tab_groups+=$expl
@@ -57,7 +57,7 @@ compadd() {
     # dscr - the string to show to users
     # word - the string to be inserted
     local dscr word i sort cnt=$#_fzf_tab_compcap
-    _fzf_tab_get -b sort sort
+    zstyle -s ":completion:$_fzf_tab_curcontext" sort sort
     for i in {1..$#__hits}; do
         word=$__hits[i] && dscr=$__dscr[i]
         if [[ -n $dscr ]]; then
@@ -67,7 +67,7 @@ compadd() {
         else
             continue
         fi
-        [[ $sort == "yes" ]] || dscr=$((i + cnt))$'\b'$dscr
+        [[ $sort != (no|false|0|off) ]] || dscr=$((i + cnt))$'\b'$dscr
         _fzf_tab_compcap[$dscr]=$__tmp_value${word:+$'\2word\2'$word}
     done
 
@@ -108,7 +108,7 @@ _fzf_tab_add_default() {
 }
 
 _fzf_tab_get() {
-    zstyle $1 "$_fzf_tab_curcontext" ${@:2}
+    zstyle $1 ":fzf-tab:$_fzf_tab_curcontext" ${@:2}
 }
 
 # Some users may still use variable
@@ -118,7 +118,6 @@ _fzf_tab_add_default insert-space ${FZF_TAB_INSERT_SPACE:-true}
 _fzf_tab_add_default query-string ${(A)=FZF_TAB_QUERY:-prefix input first}
 _fzf_tab_add_default single-group ${(A)=FZF_TAB_SINGLE_GROUP:-color header}
 _fzf_tab_add_default show-group ${FZF_TAB_SHOW_GROUP:-full}
-_fzf_tab_add_default sort true
 _fzf_tab_add_default command ${FZF_TAB_COMMAND:-fzf} $FZF_TAB_OPTS
 _fzf_tab_add_default extra-opts ''
 _fzf_tab_add_default no-group-color ${FZF_TAB_NO_GROUP_COLOR:-$'\033[37m'}
@@ -242,9 +241,9 @@ _fzf_tab_get_candidates() {
         if (( $+v[group] )); then
             local color=$group_colors[$v[group]]
             # add a hidden group index at start of string to keep group order when sorting
-            candidates+=$v[group]$'\b'$color$prefix$'\2'$k$'\2'$dsuf$'\033[00m'
+            candidates+=$v[group]$'\b'$color$prefix$'\2'$k$'\2'$dsuf
         else
-            candidates+=$no_group_color$'\2'$k$'\2'$dsuf$'\033[00m'
+            candidates+=$no_group_color$'\2'$k$'\2'$dsuf
         fi
 
         # check group with duplicate member

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -318,7 +318,7 @@ _fzf_tab_complete() {
     for choice in $choices; do
         # if disale sort
         for i in ${(k)_fzf_tab_compcap}; do
-            [[ $i != *$'\2'$choice ]] || { choice=$i; break }
+            [[ $i != *$'\b'$choice ]] || { choice=$i; break }
         done
         local -A v=("${(@ps:\2:)${_fzf_tab_compcap[$choice]}}")
         local -a args=("${(@ps:\1:)v[args]}")

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -33,7 +33,7 @@ compadd() {
     fi
 
     # store $curcontext for furthur usage
-    _fzf_tab_curcontext=:fzf_tab:${curcontext}
+    _fzf_tab_curcontext=:fzf_tab:${curcontext#:}
 
     # keep order of group description
     [[ -n $expl ]] && _fzf_tab_groups+=$expl

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -296,14 +296,17 @@ _fzf_tab_complete() {
             _fzf_tab_get -s continuous-trigger continuous_trigger
             _fzf_tab_get -a command command
             _fzf_tab_get -a extra-opts opts
-            command+=($opts)
+
+            export CTXT="${${(Av)=_fzf_tab_compcap}[1]}"
 
             if (( $#headers )); then
-                choices=$(${(eX)command} <<<${(pj:\n:)headers} <<<${(pj:\n:)candidates})
+                choices=$(${(eX)command} $opts <<<${(pj:\n:)headers} <<<${(pj:\n:)candidates})
             else
-                choices=$(${(eX)command} <<<${(pj:\n:)candidates})
+                choices=$(${(eX)command} $opts <<<${(pj:\n:)candidates})
             fi
             choices=(${${${(f)choices}%$'\2'*}#*$'\2'})
+
+            unset CTXT
             ;;
     esac
 
@@ -315,7 +318,7 @@ _fzf_tab_complete() {
     for choice in $choices; do
         # if disale sort
         for i in ${(k)_fzf_tab_compcap}; do
-            [[ $i != *$choice ]] || { choice=$i; break }
+            [[ $i != *$'\2'$choice ]] || { choice=$i; break }
         done
         local -A v=("${(@ps:\2:)${_fzf_tab_compcap[$choice]}}")
         local -a args=("${(@ps:\1:)v[args]}")

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -33,7 +33,7 @@ compadd() {
     fi
 
     # store $curcontext for furthur usage
-    _fzf_tab_curcontext=${curcontext/:[^:]#:/:fzf_tab:}
+    _fzf_tab_curcontext=:fzf_tab:${curcontext}
 
     # keep order of group description
     [[ -n $expl ]] && _fzf_tab_groups+=$expl

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+.zcompdump

--- a/test/comptest
+++ b/test/comptest
@@ -1,0 +1,173 @@
+comptestinit () {
+  setopt extendedglob
+
+  zmodload zsh/zpty || return $?
+
+  comptest_zsh=${ZSH:-zsh}
+  comptest_keymap=e
+
+  while getopts vz: opt; do
+    case $opt in
+      z) comptest_zsh="$OPTARG";;
+      v) comptest_keymap="v";;
+    esac
+  done
+  (( OPTIND > 1 )) && shift $(( OPTIND - 1 ))
+
+  export PS1="<PROMPT>"
+  zpty zsh "$comptest_zsh -f +Z"
+
+  zpty -r zsh log1 "*<PROMPT>*" || { 
+    print "first prompt hasn't appeared."
+    return 1
+  }
+
+  comptesteval \
+"export LC_ALL=${ZSH_TEST_LANG:-C}" \
+"emulate -R zsh" \
+"export ZDOTDIR=$ZTST_testdir" \
+"bindkey -$comptest_keymap" \
+'LISTMAX=10000000
+stty 38400 columns 80 rows 24 tabs -icanon -iexten
+TERM=vt100
+KEYTIMEOUT=1
+setopt zle
+autoload -U compinit
+compinit -u
+zstyle ":completion:*:default" list-colors "no=<NO>" "fi=<FI>" "di=<DI>" "ln=<LN>" "pi=<PI>" "so=<SO>" "bd=<BD>" "cd=<CD>" "ex=<EX>" "mi=<MI>" "tc=<TC>" "sp=<SP>" "lc=<LC>" "ec=<EC>\n" "rc=<RC>"
+zstyle ":completion:*" group-name ""
+zstyle ":completion:*:messages" format "<MESSAGE>%d</MESSAGE>
+"
+zstyle ":completion:*:descriptions" format "<DESCRIPTION>%d</DESCRIPTION>
+"
+zstyle ":completion:*:options" verbose yes
+zstyle ":completion:*:values" verbose yes
+setopt noalwayslastprompt listrowsfirst completeinword
+zmodload zsh/complist
+expand-or-complete-with-report () {
+  print -lr "<WIDGET><expand-or-complete>"
+  zle expand-or-complete
+  print -lr - "<LBUFFER>$LBUFFER</LBUFFER>" "<RBUFFER>$RBUFFER</RBUFFER>"
+  zle clear-screen
+  zle -R
+}
+list-choices-with-report () {
+  print -lr "<WIDGET><list-choices>"
+  zle list-choices
+  zle clear-screen
+  zle -R
+}
+comp-finish () {
+  print "<WIDGET><finish>"
+  zle kill-whole-line
+  zle clear-screen
+  zle -R
+}
+zle-finish () {
+  local buffer="$BUFFER" cursor="$CURSOR" mark="$MARK"
+  (( region_active)) || unset mark
+  BUFFER=""
+  zle -I
+  zle clear-screen
+  zle redisplay
+  print -lr "<WIDGET><finish>" "BUFFER: $buffer" "CURSOR: $cursor"
+  (( $+mark )) && print -lr "MARK: $mark"
+  zle accept-line
+}
+zle -N expand-or-complete-with-report
+zle -N list-choices-with-report
+zle -N comp-finish
+zle -N zle-finish
+bindkey "^I" expand-or-complete-with-report
+bindkey "^D" list-choices-with-report
+bindkey "^Z" comp-finish
+bindkey "^X" zle-finish
+bindkey -a "^X" zle-finish
+'
+}
+
+zpty_flush() {
+  local junk
+  if zpty -r -t zsh junk \*; then
+    (( ZTST_verbose > 2 )) && print -n -u $ZTST_fd "$*: ${(V)junk}"
+    while zpty -r -t zsh junk \* ; do
+      (( ZTST_verbose > 2 )) && print -n -u $ZTST_fd "${(V)junk}"
+    done
+    (( ZTST_verbose > 2 )) && print -u $ZTST_fd ''
+  fi
+}
+
+zpty_run() {
+  zpty -w zsh "$*"
+  zpty -r -m zsh log "*<PROMPT>*" || {
+    print "prompt hasn't appeared."
+    return 1
+  }
+}
+
+comptesteval () {
+  local tmp=/tmp/comptest.$$
+
+  print -lr - "$@" > $tmp
+  # zpty_flush Before comptesteval
+  zpty -w zsh ". $tmp"
+  zpty -r -m zsh log_eval "*<PROMPT>*" || {
+    print "prompt hasn't appeared."
+    return 1
+  }
+  zpty_flush After comptesteval
+  rm $tmp
+}
+
+comptest () {
+  input="$*"
+  zpty -n -w zsh "$input"$'\C-Z'
+  zpty -r -m zsh log "*<WIDGET><finish>*<PROMPT>*" || {
+    print "failed to invoke finish widget."
+    return 1
+  }
+
+  logs=(${(s:<WIDGET>:)log})
+  shift logs
+
+  for log in "$logs[@]"; do
+    if [[ "$log" = (#b)*$'<LBUFFER>'(*)$'</LBUFFER>\r\n<RBUFFER>'(*)$'</RBUFFER>'* ]]; then
+      print -lr "line: {$match[1]}{$match[2]}"
+    fi
+    while (( ${(N)log#*(#b)(<LC><(??)><RC>(*)<EC>|<DESCRIPTION>(*)</DESCRIPTION>|<MESSAGE>(*)</MESSAGE>|<COMPADD>(*)</COMPADD>|<INSERT_POSITIONS>(*)</INSERT_POSITIONS>|<QUERY>(*)</QUERY>)} )); do
+      log="${log[$mend[1]+1,-1]}"
+      if (( 0 <= $mbegin[2] )); then
+	if [[ $match[2] != TC && $match[3] != \ # ]]; then
+	  print -lr "$match[2]:{${match[3]%${(%):-%E}}}"
+	fi
+      elif (( 0 <= $mbegin[4] )); then
+	print -lr "DESCRIPTION:{$match[4]}"
+      elif (( 0 <= $mbegin[5] )); then
+	print -lr "MESSAGE:{$match[5]}"
+      elif (( 0 <= $mbegin[6] )); then
+        print -lr "COMPADD:{${${match[6]}//[$'\r\n']/}}"
+      elif (( 0 <= $mbegin[7] )); then
+        print -lr "INSERT_POSITIONS:{${${match[7]}//[$'\r\n']/}}"
+      elif (( 0 <= $mbegin[8] )); then
+        print -lr "QUERY:{${match[8]}}"
+      fi
+    done
+  done
+}
+
+zletest () {
+  local first=0
+  for input; do
+    # zpty_flush Before zletest
+    # sleep for $KEYTIMEOUT
+    (( first++ )) && { sleep 2 & } | read -t 0.011 -u 0 -k 1
+    zpty -n -w zsh "$input"
+  done
+  zpty -n -w zsh $'\C-X'
+  zpty -r -m zsh log "*<WIDGET><finish>*<PROMPT>*" || {
+    print "failed to invoke finish widget."
+    return 1
+  }
+  # zpty_flush After zletest
+  print -lr "${(@)${(@ps:\r\n:)log##*<WIDGET><finish>}[2,-2]}"
+}

--- a/test/comptest
+++ b/test/comptest
@@ -134,7 +134,7 @@ comptest () {
     if [[ "$log" = (#b)*$'<LBUFFER>'(*)$'</LBUFFER>\r\n<RBUFFER>'(*)$'</RBUFFER>'* ]]; then
       print -lr "line: {$match[1]}{$match[2]}"
     fi
-    while (( ${(N)log#*(#b)(<LC><(??)><RC>(*)<EC>|<DESCRIPTION>(*)</DESCRIPTION>|<MESSAGE>(*)</MESSAGE>|<COMPADD>(*)</COMPADD>|<INSERT_POSITIONS>(*)</INSERT_POSITIONS>|<QUERY>(*)</QUERY>)} )); do
+    while (( ${(N)log#*(#b)(<LC><(??)><RC>(*)<EC>|<DESCRIPTION>(*)</DESCRIPTION>|<MESSAGE>(*)</MESSAGE>|<COMPADD>(*)</COMPADD>|<INSERT_POSITIONS>(*)</INSERT_POSITIONS>|<QUERY>(*)</QUERY>|<WARN>(*)</WARN>)} )); do
       log="${log[$mend[1]+1,-1]}"
       if (( 0 <= $mbegin[2] )); then
 	if [[ $match[2] != TC && $match[3] != \ # ]]; then
@@ -150,6 +150,8 @@ comptest () {
         print -lr "INSERT_POSITIONS:{${${match[7]}//[$'\r\n']/}}"
       elif (( 0 <= $mbegin[8] )); then
         print -lr "QUERY:{${match[8]}}"
+      elif (( 0 <= $mbegin[9] )); then
+        print -lr "WARN:{${match[9]}}"
       fi
     done
   done

--- a/test/fzftab.ztst
+++ b/test/fzftab.ztst
@@ -1,0 +1,113 @@
+# Tests for fzf tab.
+
+%prep
+  unset -m LC_\*
+  ZSH_TEST_LANG=
+  langs=(en_{US,GB}.{UTF-,utf}8 en.UTF-8
+         $(locale -a 2>/dev/null | egrep 'utf8|UTF-8'))
+  for LANG in $langs; do
+    if [[ é = ? ]]; then
+      ZSH_TEST_LANG=$LANG
+      break;
+    fi
+  done
+  if [[ $OSTYPE = cygwin ]]; then
+    ZTST_unimplemented="the zsh/zpty module does not work on Cygwin"
+  elif ( zmodload zsh/zpty 2>/dev/null ); then
+    . $ZTST_srcdir/comptest
+    mkdir comp.tmp
+    cd comp.tmp
+    comptestinit -z zsh &&
+    {
+      comptesteval 'compdef _tst tst'
+      mkdir dir1 &&
+      mkdir dir2 &&
+      touch file1 &&
+      touch file2
+    }
+  else
+    ZTST_unimplemented="the zsh/zpty module is not available"
+  fi
+
+  comptesteval ". $ZTST_srcdir/../fzf-tab.zsh"
+  comptesteval "zstyle ':fzf-tab:*' command $ZTST_srcdir/select -n 1 -h '\$#headers' -q '\"\$query\"'"
+  comptesteval '
+  zstyle ":fzf-tab:*" no-group-color "<LC><C0><RC>"
+  zstyle ":fzf-tab:*" group-colors "<LC><C1><RC>" "<LC><C2><RC>" "<LC><C3><RC>" "<LC><C4><RC>"
+  _fzf_tab_orig_widget=expand-or-complete
+  fzf-tab-complete-with-report() {
+    print -lr "<WIDGET><fzf-tab-complete>"
+    zle fzf-tab-complete 2>&1
+    print -lr - "<LBUFFER>$LBUFFER</LBUFFER>" "<RBUFFER>$RBUFFER</RBUFFER>"
+    zle clear-screen
+    zle -R
+  }
+  zle -N fzf-tab-complete-with-report
+  bindkey "^I" fzf-tab-complete-with-report
+  '
+
+%test
+
+  comptest $': \t'
+0:directories and files
+>line: {: }{}
+>QUERY:{}
+>DESCRIPTION:{file}
+>C1:{dir1/}
+>C1:{dir2/}
+>C1:{file1}
+>C1:{file2}
+
+  comptest $': d\t'
+0:prefix
+>line: {: d}{}
+>QUERY:{dir}
+>DESCRIPTION:{file}
+>C1:{dir1/}
+>C1:{dir2/}
+
+  comptesteval '_tst () { compadd d c b a }'
+  comptest $'tst \t'
+0:normal
+>line: {tst a }{}
+>QUERY:{}
+>C0:{a}
+>C0:{b}
+>C0:{c}
+>C0:{d}
+
+  comptesteval 'zstyle ":completion:*:tst:*" sort false'
+  comptest $'tst \t'
+0:no sort
+>line: {tst d }{}
+>QUERY:{}
+>C0:{d}
+>C0:{c}
+>C0:{b}
+>C0:{a}
+
+  comptesteval 'zstyle ":fzf-tab:*:tst:*" insert-space false'
+  comptest $'tst \t'
+0:no space
+>line: {tst d}{}
+>QUERY:{}
+>C0:{d}
+>C0:{c}
+>C0:{b}
+>C0:{a}
+
+  comptesteval 'zstyle ":fzf-tab:*:tst:*" extra-opts -n 1,2'
+  comptest $'tst \t'
+0:multi select
+>line: {tst c d }{}
+>QUERY:{}
+>C0:{d}
+>C0:{c}
+>C0:{b}
+>C0:{a}
+
+
+%clean
+
+  zmodload -ui zsh/zpty
+

--- a/test/fzftab.ztst
+++ b/test/fzftab.ztst
@@ -106,6 +106,15 @@
 >C0:{b}
 >C0:{a}
 
+  comptest $': *\t'
+0:expand
+>line: {: dir1 dir2 file1 file2 }{}
+
+  comptesteval 'zstyle ":completion:*:warnings" format "<WARN>%d</WARN>"'
+  comptest $': asd\t'
+0:warnings
+>line: {: asd}{}
+>WARN:{`file'}
 
 %clean
 

--- a/test/runtests.zsh
+++ b/test/runtests.zsh
@@ -1,0 +1,27 @@
+#!/bin/zsh -f
+
+emulate zsh
+
+# Run all specified tests, keeping count of which succeeded.
+# The reason for this extra layer above the test script is to
+# protect from catastrophic failure of an individual test.
+# We could probably do that with subshells instead.
+
+integer success failure skipped retval
+for file in ${@:1}; do
+  zsh +Z -f ./ztst.zsh $file
+  retval=$?
+  if (( $retval == 2 )); then
+    (( skipped++ ))
+  elif (( $retval )); then
+    (( failure++ ))
+  else
+    (( success++ ))
+  fi
+done
+print "**************************************
+$success successful test script${${success:#1}:+s}, \
+$failure failure${${failure:#1}:+s}, \
+$skipped skipped
+**************************************"
+return $(( failure ? 1 : 0 ))

--- a/test/select
+++ b/test/select
@@ -20,7 +20,7 @@ done
 lines[1,headers]=()
 
 for i in {1..$#lines}; do
-    print -r -- ${lines[i]//$'\2'}"<EC>" >&2
+    print -r -- ${lines[i]//$'\0'}"<EC>" >&2
 done
 
 

--- a/test/select
+++ b/test/select
@@ -1,0 +1,29 @@
+#!/usr/bin/env zsh
+
+zmodload zsh/zutil
+
+local -A headers range query
+
+zparseopts -E h:=headers n:=range q:=query
+
+print -r -- "<QUERY>${query//\"/}</QUERY>" >&2
+
+local -a lines=() 
+while read input; do
+    lines+=($input)
+done
+
+for ((i = 1; i <= headers; i++)); do
+    print -r -- $lines[i] >&2
+done
+
+lines[1,headers]=()
+
+for i in {1..$#lines}; do
+    print -r -- ${lines[i]//$'\2'}"<EC>" >&2
+done
+
+
+for i in ${(s:,:)range}; do
+    print -r -- $lines[i]
+done

--- a/test/ztst.zsh
+++ b/test/ztst.zsh
@@ -1,0 +1,581 @@
+#!/bin/zsh -f
+# The line above is just for convenience.  Normally tests will be run using
+# a specified version of zsh.  With dynamic loading, any required libraries
+# must already have been installed in that case.
+#
+# Takes one argument: the name of the test file.  Currently only one such
+# file will be processed each time ztst.zsh is run.  This is slower, but
+# much safer in terms of preserving the correct status.
+# To avoid namespace pollution, all functions and parameters used
+# only by the script begin with ZTST_.
+#
+# Options (without arguments) may precede the test file argument; these
+# are interpreted as shell options to set.  -x is probably the most useful.
+
+# Produce verbose messages if non-zero.
+# If 1, produce reports of tests executed; if 2, also report on progress.
+# Defined in such a way that any value from the environment is used.
+: ${ZTST_verbose:=0}
+
+# We require all options to be reset, not just emulation options.
+# Unfortunately, due to the crud which may be in /etc/zshenv this might
+# still not be good enough.  Maybe we should trick it somehow.
+emulate -R zsh
+
+# Ensure the locale does not screw up sorting.  Don't supply a locale
+# unless there's one set, to minimise problems.
+[[ -n $LC_ALL ]] && LC_ALL=C
+[[ -n $LC_COLLATE ]] && LC_COLLATE=C
+[[ -n $LC_NUMERIC ]] && LC_NUMERIC=C
+[[ -n $LC_MESSAGES ]] && LC_MESSAGES=C
+[[ -n $LANG ]] && LANG=C
+
+# Don't propagate variables that are set by default in the shell.
+typeset +x WORDCHARS
+
+# We need to be able to save and restore the options used in the test.
+# We use the $options variable of the parameter module for this.
+zmodload zsh/parameter
+
+# Note that both the following are regular arrays, since we only use them
+# in whole array assignments to/from $options.
+# Options set in test code (i.e. by default all standard options)
+ZTST_testopts=(${(kv)options})
+
+setopt extendedglob nonomatch
+while [[ $1 = [-+]* ]]; do
+  set $1
+  shift
+done
+# Options set in main script
+ZTST_mainopts=(${(kv)options})
+
+# We run in the current directory, so remember it.
+ZTST_testdir=$PWD
+ZTST_testname=$1
+
+integer ZTST_testfailed
+
+# This is POSIX nonsense.  Because of the vague feeling someone, somewhere
+# may one day need to examine the arguments of "tail" using a standard
+# option parser, every Unix user in the world is expected to switch
+# to using "tail -n NUM" instead of "tail -NUM".  Older versions of
+# tail don't support this.
+tail() {
+  emulate -L zsh
+
+  if [[ -z $TAIL_SUPPORTS_MINUS_N ]]; then
+    local test
+    test=$(echo "foo\nbar" | command tail -n 1 2>/dev/null)
+    if [[ $test = bar ]]; then
+      TAIL_SUPPORTS_MINUS_N=1
+    else
+      TAIL_SUPPORTS_MINUS_N=0
+    fi
+  fi
+
+  integer argi=${argv[(i)-<->]}
+
+  if [[ $argi -le $# && $TAIL_SUPPORTS_MINUS_N = 1 ]]; then
+    argv[$argi]=(-n ${argv[$argi][2,-1]})
+  fi
+
+  command tail "$argv[@]"
+}
+
+# The source directory is not necessarily the current directory,
+# but if $0 doesn't contain a `/' assume it is.
+if [[ $0 = */* ]]; then
+  ZTST_srcdir=${0%/*}
+else
+  ZTST_srcdir=$PWD
+fi
+[[ $ZTST_srcdir = /* ]] || ZTST_srcdir="$ZTST_testdir/$ZTST_srcdir"
+
+
+: ${TMPPREFIX:=/tmp/zsh}
+ZTST_tmp=${TMPPREFIX}.ztst.$$
+if ! rm -f $ZTST_tmp || ! mkdir -p $ZTST_tmp || ! chmod go-w $ZTST_tmp; then
+  print "Can't create $ZTST_tmp for exclusive use." >&2
+  exit 1
+fi
+# Temporary files for redirection inside tests.
+ZTST_in=${ZTST_tmp}/ztst.in
+# hold the expected output
+ZTST_out=${ZTST_tmp}/ztst.out
+ZTST_err=${ZTST_tmp}/ztst.err
+# hold the actual output from the test
+ZTST_tout=${ZTST_tmp}/ztst.tout
+ZTST_terr=${ZTST_tmp}/ztst.terr
+
+ZTST_cleanup() {
+  cd $ZTST_testdir
+  rm -rf $ZTST_testdir/dummy.tmp $ZTST_testdir/*.tmp(N) ${ZTST_tmp}
+}
+
+# This cleanup always gets performed, even if we abort.  Later,
+# we should try and arrange that any test-specific cleanup
+# always gets called as well.
+##trap 'print cleaning up...
+##ZTST_cleanup' INT QUIT TERM
+# Make sure it's clean now.
+rm -rf dummy.tmp *.tmp
+
+# Report failure.  Note that all output regarding the tests goes to stdout.
+# That saves an unpleasant mixture of stdout and stderr to sort out.
+ZTST_testfailed() {
+  print -r "Test $ZTST_testname failed: $1"
+  if [[ -n $ZTST_message ]]; then
+    print -r "Was testing: $ZTST_message"
+  fi
+  print -r "$ZTST_testname: test failed."
+  if [[ -n $ZTST_failmsg ]]; then
+    print -r "The following may (or may not) help identifying the cause:
+$ZTST_failmsg"
+  fi
+  ZTST_testfailed=1
+  return 1
+}
+
+# Print messages if $ZTST_verbose is non-empty
+ZTST_verbose() {
+  local lev=$1
+  shift
+  if [[ -n $ZTST_verbose && $ZTST_verbose -ge $lev ]]; then
+    print -r -u $ZTST_fd -- $*
+  fi
+}
+ZTST_hashmark() {
+  if [[ ZTST_verbose -le 0 && -t $ZTST_fd ]]; then
+    print -n -u$ZTST_fd -- ${(pl:SECONDS::\#::\#\r:)}
+  fi
+  (( SECONDS > COLUMNS+1 && (SECONDS -= COLUMNS) ))
+}
+
+if [[ ! -r $ZTST_testname ]]; then
+  ZTST_testfailed "can't read test file."
+  exit 1
+fi
+
+exec {ZTST_fd}>&1
+exec {ZTST_input}<$ZTST_testname
+
+# The current line read from the test file.
+ZTST_curline=''
+# The current section being run
+ZTST_cursect=''
+
+# Get a new input line.  Don't mangle spaces; set IFS locally to empty.
+# We shall skip comments at this level.
+ZTST_getline() {
+  local IFS=
+  while true; do
+    read -u $ZTST_input -r ZTST_curline || return 1
+    [[ $ZTST_curline == \#* ]] || return 0
+  done
+}
+
+# Get the name of the section.  It may already have been read into
+# $curline, or we may have to skip some initial comments to find it.
+# If argument present, it's OK to skip the reset of the current section,
+# so no error if we find garbage.
+ZTST_getsect() {
+  local match mbegin mend
+
+  while [[ $ZTST_curline != '%'(#b)([[:alnum:]]##)* ]]; do
+    ZTST_getline || return 1
+    [[ $ZTST_curline = [[:blank:]]# ]] && continue
+    if [[ $# -eq 0 && $ZTST_curline != '%'[[:alnum:]]##* ]]; then
+      ZTST_testfailed "bad line found before or after section:
+$ZTST_curline"
+      exit 1
+    fi
+  done
+  # have the next line ready waiting
+  ZTST_getline
+  ZTST_cursect=${match[1]}
+  ZTST_verbose 2 "ZTST_getsect: read section name: $ZTST_cursect"
+  return 0
+}
+
+# Read in an indented code chunk for execution
+ZTST_getchunk() {
+  # Code chunks are always separated by blank lines or the
+  # end of a section, so if we already have a piece of code,
+  # we keep it.  Currently that shouldn't actually happen.
+  ZTST_code=''
+  # First find the chunk.
+  while [[ $ZTST_curline = [[:blank:]]# ]]; do
+    ZTST_getline || break
+  done
+  while [[ $ZTST_curline = [[:blank:]]##[^[:blank:]]* ]]; do
+    ZTST_code="${ZTST_code:+${ZTST_code}
+}${ZTST_curline}"
+    ZTST_getline || break
+  done
+  ZTST_verbose 2 "ZTST_getchunk: read code chunk:
+$ZTST_code"
+  [[ -n $ZTST_code ]]
+}
+
+# Read in a piece for redirection.
+ZTST_getredir() {
+  local char=${ZTST_curline[1]} fn
+  ZTST_redir=${ZTST_curline[2,-1]}
+  while ZTST_getline; do
+    [[ $ZTST_curline[1] = $char ]] || break
+    ZTST_redir="${ZTST_redir}
+${ZTST_curline[2,-1]}"
+  done
+  ZTST_verbose 2 "ZTST_getredir: read redir for '$char':
+$ZTST_redir"
+
+  case $char in
+    ('<') fn=$ZTST_in
+    ;;
+    ('>') fn=$ZTST_out
+    ;;
+    ('?') fn=$ZTST_err
+    ;;
+    (*)  ZTST_testfailed "bad redir operator: $char"
+    return 1
+    ;;
+  esac
+  if [[ $ZTST_flags = *q* && $char = '<' ]]; then
+    # delay substituting output until variables are set
+    print -r -- "${(e)ZTST_redir}" >>$fn
+  else
+    print -r -- "$ZTST_redir" >>$fn
+  fi
+
+  return 0
+}
+
+# Execute an indented chunk.  Redirections will already have
+# been set up, but we need to handle the options.
+ZTST_execchunk() {
+  setopt localloops # don't let continue & break propagate out
+  options=($ZTST_testopts)
+  () {
+      unsetopt localloops
+      eval "$ZTST_code"
+  }
+  ZTST_status=$?
+  # careful... ksh_arrays may be in effect.
+  ZTST_testopts=(${(kv)options[*]})
+  options=(${ZTST_mainopts[*]})
+  ZTST_verbose 2 "ZTST_execchunk: status $ZTST_status"
+  return $ZTST_status
+}
+
+# Functions for preparation and cleaning.
+# When cleaning up (non-zero string argument), we ignore status.
+ZTST_prepclean() {
+  # Execute indented code chunks.
+  while ZTST_getchunk; do
+    ZTST_execchunk >/dev/null || [[ -n $1 ]] || {
+      [[ -n "$ZTST_unimplemented" ]] ||
+      ZTST_testfailed "non-zero status from preparation code:
+$ZTST_code" && return 0
+    }
+  done
+}
+
+# diff wrapper
+ZTST_diff() {
+  emulate -L zsh
+  setopt extendedglob
+
+  local diff_out
+  integer diff_pat diff_ret
+
+  case $1 in
+    (p)
+    diff_pat=1
+    ;;
+
+    (d)
+    ;;
+
+    (*)
+    print "Bad ZTST_diff code: d for diff, p for pattern match"
+    ;;
+  esac
+  shift
+      
+  if (( diff_pat )); then
+    local -a diff_lines1 diff_lines2
+    integer failed i l
+    local p
+
+    diff_lines1=("${(f@)$(<$argv[-2])}")
+    diff_lines2=("${(f@)$(<$argv[-1])}")
+    if (( ${#diff_lines1} != ${#diff_lines2} )); then
+      failed=1
+      print -r "Pattern match failed, line mismatch (${#diff_lines1}/${#diff_lines2}):"
+    else
+      for (( i = 1; i <= ${#diff_lines1}; i++ )); do
+	if [[ ${diff_lines2[i]} != ${~diff_lines1[i]} ]]; then
+	  failed=1
+	  print -r "Pattern match failed, line $i:"
+	  break
+	fi
+      done
+    fi
+    if (( failed )); then
+      for (( l = 1; l <= ${#diff_lines1}; ++l )); do
+	if (( l == i )); then
+	  p="-"
+	else
+	  p=" "
+	fi
+	print -r -- "$p<${diff_lines1[l]}"
+      done
+      for (( l = 1; l <= ${#diff_lines2}; ++l )); do
+	if (( l == i )); then
+	  p="+"
+	else
+	  p=" "
+	fi
+	print -r -- "$p>${diff_lines2[l]}"
+      done
+      diff_ret=1
+    fi
+  else
+    diff_out=$(diff -a "$@")
+    diff_ret="$?"
+    if [[ "$diff_ret" != "0" ]]; then
+      print -r -- "$diff_out"
+    fi
+  fi
+
+  return "$diff_ret"
+}
+    
+ZTST_test() {
+  local last match mbegin mend found substlines
+  local diff_out diff_err
+  local ZTST_skip
+  integer expected_to_fail
+
+  while true; do
+    rm -f $ZTST_in $ZTST_out $ZTST_err
+    touch $ZTST_in $ZTST_out $ZTST_err
+    ZTST_message=''
+    ZTST_failmsg=''
+    found=0
+    diff_out=d
+    diff_err=d
+
+    ZTST_verbose 2 "ZTST_test: looking for new test"
+
+    while true; do
+      ZTST_verbose 2 "ZTST_test: examining line:
+$ZTST_curline"
+      case $ZTST_curline in
+	(%*) if [[ $found = 0 ]]; then
+	      break 2
+	    else
+	      last=1
+	      break
+	    fi
+	    ;;
+	([[:space:]]#)
+	    if [[ $found = 0 ]]; then
+	      ZTST_getline || break 2
+	      continue
+	    else
+	      break
+	    fi
+	    ;;
+	([[:space:]]##[^[:space:]]*) ZTST_getchunk
+	  if [[ $ZTST_curline == (#b)([-0-9]##)([[:alpha:]]#)(:*)# ]]; then
+	    ZTST_xstatus=$match[1]
+	    ZTST_flags=$match[2]
+	    ZTST_message=${match[3]:+${match[3][2,-1]}}
+	  else
+	    ZTST_testfailed "expecting test status at:
+$ZTST_curline"
+	    return 1
+	  fi
+	  ZTST_getline
+	  found=1
+	  ;;
+	('<'*) ZTST_getredir || return 1
+	  found=1
+	  ;;
+	('*>'*)
+	  ZTST_curline=${ZTST_curline[2,-1]}
+	  diff_out=p
+	  ;&
+	('>'*)
+	  ZTST_getredir || return 1
+	  found=1
+	  ;;
+	('*?'*)
+	  ZTST_curline=${ZTST_curline[2,-1]}
+	  diff_err=p
+	  ;&
+	('?'*)
+	  ZTST_getredir || return 1
+	  found=1
+	  ;;
+	('F:'*) ZTST_failmsg="${ZTST_failmsg:+${ZTST_failmsg}
+}  ${ZTST_curline[3,-1]}"
+	  ZTST_getline
+	  found=1
+          ;;
+	(*) ZTST_testfailed "bad line in test block:
+$ZTST_curline"
+	  return 1
+          ;;
+      esac
+    done
+
+    # If we found some code to execute...
+    if [[ -n $ZTST_code ]]; then
+      ZTST_hashmark
+      ZTST_verbose 1 "Running test: $ZTST_message"
+      ZTST_verbose 2 "ZTST_test: expecting status: $ZTST_xstatus"
+      ZTST_verbose 2 "Input: $ZTST_in, output: $ZTST_out, error: $ZTST_terr"
+
+      ZTST_execchunk <$ZTST_in >$ZTST_tout 2>$ZTST_terr
+
+      if [[ -n $ZTST_skip ]]; then
+	ZTST_verbose 0 "Test case skipped: $ZTST_skip"
+	ZTST_skip=
+	if [[ -n $last ]]; then
+	  break
+	else
+	  continue
+	fi
+      fi
+
+      if [[ $ZTST_flags = *f* ]]; then
+        expected_to_fail=1
+        ZTST_xfail_diff() { ZTST_diff "$@" > /dev/null }
+        ZTST_diff=ZTST_xfail_diff
+      else
+        expected_to_fail=0
+        ZTST_diff=ZTST_diff
+      fi
+
+      # First check we got the right status, if specified.
+      if [[ $ZTST_xstatus != - && $ZTST_xstatus != $ZTST_status ]]; then
+        if (( expected_to_fail )); then
+          ZTST_verbose 1 "Test failed, as expected."
+          continue
+        fi
+	ZTST_testfailed "bad status $ZTST_status, expected $ZTST_xstatus from:
+$ZTST_code${$(<$ZTST_terr):+
+Error output:
+$(<$ZTST_terr)}"
+	return 1
+      fi
+
+      ZTST_verbose 2 "ZTST_test: test produced standard output:
+$(<$ZTST_tout)
+ZTST_test: and standard error:
+$(<$ZTST_terr)"
+
+      # Now check output and error.
+      if [[ $ZTST_flags = *q* && -s $ZTST_out ]]; then
+	substlines="$(<$ZTST_out)"
+	rm -rf $ZTST_out
+	print -r -- "${(e)substlines}" >$ZTST_out
+      fi
+      if [[ $ZTST_flags != *d* ]] && ! $ZTST_diff $diff_out -u $ZTST_out $ZTST_tout; then
+        if (( expected_to_fail )); then
+          ZTST_verbose 1 "Test failed, as expected."
+          continue
+        fi
+	ZTST_testfailed "output differs from expected as shown above for:
+$ZTST_code${$(<$ZTST_terr):+
+Error output:
+$(<$ZTST_terr)}"
+	return 1
+      fi
+      if [[ $ZTST_flags = *q* && -s $ZTST_err ]]; then
+	substlines="$(<$ZTST_err)"
+	rm -rf $ZTST_err
+	print -r -- "${(e)substlines}" >$ZTST_err
+      fi
+      if [[ $ZTST_flags != *D* ]] && ! $ZTST_diff $diff_err -u $ZTST_err $ZTST_terr; then
+        if (( expected_to_fail )); then
+          ZTST_verbose 1 "Test failed, as expected."
+          continue
+        fi
+	ZTST_testfailed "error output differs from expected as shown above for:
+$ZTST_code"
+	return 1
+      fi
+      if (( expected_to_fail )); then
+        ZTST_testfailed "test was expected to fail, but passed."
+        return 1
+      fi
+    fi
+    ZTST_verbose 1 "Test successful."
+    [[ -n $last ]] && break
+  done
+
+  ZTST_verbose 2 "ZTST_test: all tests successful"
+
+  # reset message to keep ZTST_testfailed output correct
+  ZTST_message=''
+}
+
+
+# Remember which sections we've done.
+typeset -A ZTST_sects
+ZTST_sects=(prep 0 test 0 clean 0)
+
+print "$ZTST_testname: starting."
+
+# Now go through all the different sections until the end.
+# prep section may set ZTST_unimplemented, in this case the actual
+# tests will be skipped
+ZTST_skipok=
+ZTST_unimplemented=
+while [[ -z "$ZTST_unimplemented" ]] && ZTST_getsect $ZTST_skipok; do
+  case $ZTST_cursect in
+    (prep) if (( ${ZTST_sects[prep]} + ${ZTST_sects[test]} + \
+	        ${ZTST_sects[clean]} )); then
+	    ZTST_testfailed "\`prep' section must come first"
+            exit 1
+	  fi
+	  ZTST_prepclean
+	  ZTST_sects[prep]=1
+	  ;;
+    (test)
+	  if (( ${ZTST_sects[test]} + ${ZTST_sects[clean]} )); then
+	    ZTST_testfailed "bad placement of \`test' section"
+	    exit 1
+	  fi
+	  # careful here: we can't execute ZTST_test before || or &&
+	  # because that affects the behaviour of traps in the tests.
+	  ZTST_test
+	  (( $? )) && ZTST_skipok=1
+	  ZTST_sects[test]=1
+	  ;;
+    (clean)
+	   if (( ${ZTST_sects[test]} == 0 || ${ZTST_sects[clean]} )); then
+	     ZTST_testfailed "bad use of \`clean' section"
+	   else
+	     ZTST_prepclean 1
+	     ZTST_sects[clean]=1
+	   fi
+	   ZTST_skipok=
+	   ;;
+    *) ZTST_testfailed "bad section name: $ZTST_cursect"
+       ;;
+  esac
+done
+
+if [[ -n "$ZTST_unimplemented" ]]; then
+  print "$ZTST_testname: skipped ($ZTST_unimplemented)"
+  ZTST_testfailed=2
+elif (( ! $ZTST_testfailed )); then
+  print "$ZTST_testname: all tests successful."
+fi
+ZTST_cleanup
+exit $(( ZTST_testfailed ))


### PR DESCRIPTION
Fix #29 

Also provide many other features.

```zsh
# disable sort when completing options of any command
zstyle ':completion:complete:*:options' sort false

# use input as query string when completing zlua
zstyle ':fzf-tab:complete:_zlua:*' query-string input

# give a preview when completing `kill`
zstyle ':completion:*:*:*:*:processes' command "ps -u $USER -o pid,user,comm,cmd -w -w"
zstyle ':fzf-tab:complete:kill:argument-rest' extra-opts '--preview=echo $(<{f})' --preview-window=down:3:wrap

# (experimental) give a preview of directory when compleing cd
local extract="
# trim input
in=\${\${\"\$(<{f})\"%\$'\0'*}#*\$'\0'}
# get ctxt for current completion
local -A ctxt=(\"\${(@ps:\2:)CTXT}\")
"
zstyle ':fzf-tab:complete:cd*' extra-opts --preview=$extract"exa -1 --color=always \${~ctxt[hpre]}\$in"
```