### PR TITLE
minor and not-so-minor cleanup of the recent changes

### DIFF
--- a/test/fzftab.ztst
+++ b/test/fzftab.ztst
@@ -34,7 +34,6 @@
   comptesteval '
   zstyle ":fzf-tab:*" no-group-color "<LC><C0><RC>"
   zstyle ":fzf-tab:*" group-colors "<LC><C1><RC>" "<LC><C2><RC>" "<LC><C3><RC>" "<LC><C4><RC>"
-  _fzf_tab_orig_widget=expand-or-complete
   fzf-tab-complete-with-report() {
     print -lr "<WIDGET><fzf-tab-complete>"
     zle fzf-tab-complete 2>&1


### PR DESCRIPTION
- Avoid running code with unknown options whenever possible. Put initialization code in an anonymous function with `emulate -L zsh`.
- Use only two sets of options for all code: (1) user-defined options only when it's strictly necessary; (2) the same set of "good" options everywhere else. This makes it much easier to reason about code.
- Remove `_ZSH_FZF_TAB_DISABLED`. It's inconsistently named, awkwardly used and is unnecessary.
- Don't rely on undocumented implementation details of zsh-autosuggestions.