### PR TITLE
Bug fix: don't eat prompt line on continuous trigger

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -418,7 +418,12 @@ fzf-tab-complete() {
         } always {
             IN_FZF_TAB=0
         }
-        zle redisplay
+        if (( _fzf_tab_continue )); then
+          zle .reset-prompt
+          zle -R
+        else
+          zle redisplay
+        fi
     done
 }
 


### PR DESCRIPTION
To reproduce:

    git clone https://github.com/Aloxaf/fzf-tab.git
    zsh -f
    autoload -Uz compinit; compinit; source ~/fzf-tab/fzf-tab.zsh
    ls /<TAB>
    /

Expected:

    ❯ zsh -f
    adam% autoload -Uz compinit; compinit; source ~/fzf-tab/fzf-tab.zsh
    adam% ls /bin/
    >
    167/167
    > bash

Note that current prompt shows `adam% ls /bin/`.

Actual:

    ❯ zsh -f
    adam% autoload -Uz compinit; compinit; source ~/fzf-tab/fzf-tab.zsh
    >
      167/167
    > bash

Note that current prompt is missing.