### PR TITLE
Undo completions from contiguous trigger one by one

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -419,6 +419,7 @@ fzf-tab-complete() {
             IN_FZF_TAB=0
         }
         if (( _fzf_tab_continue )); then
+          zle .split-undo
           zle .reset-prompt
           zle -R
         else

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -418,7 +418,12 @@ fzf-tab-complete() {
         } always {
             IN_FZF_TAB=0
         }
-        zle redisplay
+        if (( _fzf_tab_continue )); then
+          zle .reset-prompt
+          zle -R
+        else
+          zle redisplay
+        fi
     done
 }
 


### PR DESCRIPTION
Currently, when you invoke `fzf-tab-complete`, insert several completions with continous trigger and invoke `undo`, everything added by `fzf-tab-complete` gets removed. With this PR only the last completion gets removed.

To demonstrate:

    zsh -f
    autoload -Uz compinit; compinit; source ~/fzf-tab/fzf-tab.zsh
    ls /<TAB>
    usr/
    bin<ENTER>
    <CTRL-X><CTRL-U>

This PR should merge cleanly after #87.