### PR TITLE
[Fix #112] Set DL_EXT=bundle if $OSTYPE is darwin*

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -595,8 +595,12 @@ toggle-fzf-tab() {
 }
 
 build-fzf-tab-module() {
+  local MACOS
+  if [[ ${OSTYPE} == darwin* ]]; then
+    MACOS=true
+  fi
   pushd $FZF_TAB_HOME/modules
-  CPPFLAGS=-I/usr/local/include CFLAGS="-g -Wall -O3" LDFLAGS=-L/usr/local/lib ./configure --disable-gdbm --without-tcsetpgrp
+  CPPFLAGS=-I/usr/local/include CFLAGS="-g -Wall -O3" LDFLAGS=-L/usr/local/lib ./configure --disable-gdbm --without-tcsetpgrp ${MACOS:+DL_EXT=bundle}
   make -j
   popd
 }


### PR DESCRIPTION
This PR adds `DL_EXT=bundle` to the arguments of `./configure` when the OS is macOS (detected by `[[ ${OSTYPE} == darwin* ]]`), changing the extension of the compiled module from `.so` to `.bundle`, which `zmodload` would expect in macOS. This fixes #112