### PR TITLE
fix _complete_tag calling _main_complete with args

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -384,7 +384,7 @@ _fzf_tab_complete() {
     local -Ua _fzf_tab_groups
     local choice choices _fzf_tab_curcontext continuous_trigger ignore bs=$'\2' nul=$'\0'
 
-    _fzf_tab__main_complete  # must run with user options; don't move `emulate -L zsh` above this line
+    _fzf_tab__main_complete "$@" # must run with user options; don't move `emulate -L zsh` above this line
 
     emulate -L zsh -o extended_glob
 
@@ -570,7 +570,7 @@ enable-fzf-tab() {
 
     # hook _main_complete to trigger fzf-tab
     functions[_fzf_tab__main_complete]=$functions[_main_complete]
-    function _main_complete() { _fzf_tab_complete }
+    function _main_complete() { _fzf_tab_complete "$@" }
 
     # TODO: This is not a full support, see #47
     # _approximate will also hook compadd


### PR DESCRIPTION
this is the root cause of https://github.com/Aloxaf/fzf-tab/issues/72.

ZSH lib file `_complete_tag`:

```sh
_main_complete - '' _wanted etags expl 'emacs tags' \
      compadd -a c_tags_array
elif [[ -f $c_path$c_tagsfile ]]; then
  # tags doesn't have as much in, but the tag is easy to find.
  # we can use awk here.
  c_tags_array=($(awk '{ print $1 }' $c_path$c_tagsfile))
  _main_complete - '' _wanted vtags expl 'vi tags' compadd -a c_tags_array
```

when fzf-tab hooks _main_complete, it must pass args to original function or else infinite recursion results when calling _main_complete without args.

ZSH lib file `_main_complete` uses positional arguments:
```
if (( $# )); then
  if [[ "$1" = - ]]; then
    if [[ $# -lt 3 ]]; then
      _completers=()
    else
      _completers=( "$2" )
      call=yes
    fi
  else
    _completers=( "$@" )
  fi
else
  zstyle -a ":completion:${curcontext}:" completer _completers ||
      _completers=( _complete _ignored )
fi
```