### PR TITLE
Check tab groups exist before hiding

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -370,7 +370,7 @@ _fzf_tab_get_candidates() {
     typeset -gUa candidates=("${(@)tcandidates//[0-9]#$bs}")
 
     # hide needless group
-    if [[ $show_group == brief ]]; then
+    if [[ $show_group == brief && -n ${_fzf_tab_groups[@]} ]]; then
         local i indexs=({1..$#_fzf_tab_groups})
         for i in ${indexs:|duplicate_groups}; do
             # NOTE: _fzf_tab_groups is unique array


### PR DESCRIPTION
When `show-group` is set to brief, an error is raised by commands that don't provide a group. This happens in particular for commands using bash completion scripts like `aws`.
```sh
_fzf_tab_get_candidates:105: _fzf_tab_groups: assignment to invalid subscript range
```

This just adds a simple check for if the list is empty before accessing it