### PR TITLE
feat: more powerful preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,25 +117,17 @@ zstyle ':completion:complete:*:options' sort false
 # use input as query string when completing zlua
 zstyle ':fzf-tab:complete:_zlua:*' query-string input
 
-# (experimental, may change in the future)
-# some boilerplate code to define the variable `extract` which will be used later
-# please remember to copy them
-local extract="
-# trim input(what you select)
-local in=\${\${\"\$(<{f})\"%\$'\0'*}#*\$'\0'}
-# get ctxt for current completion(some thing before or after the current word)
-local -A ctxt=(\"\${(@ps:\2:)CTXT}\")
-# real path
-local realpath=\${ctxt[IPREFIX]}\${ctxt[hpre]}\$in
-realpath=\${(Qe)~realpath}
-"
+# `$fzf_tab_preview_init` contains some boilerplate code to init some useful variables:
+# $in       - what you select
+# $group    - the group name of what you select
+# $realpath - use this if what you select is a file name or path
 
 # give a preview of commandline arguments when completing `kill`
 zstyle ':completion:*:*:*:*:processes' command "ps -u $USER -o pid,user,comm,cmd -w -w"
-zstyle ':fzf-tab:complete:kill:argument-rest' extra-opts --preview=$extract'ps --pid=$in[(w)1] -o cmd --no-headers -w -w' --preview-window=down:3:wrap
+zstyle ':fzf-tab:complete:kill:argument-rest' extra-opts --preview=$fzf_tab_preview_init'ps --pid=$in[(w)1] -o cmd --no-headers -w -w' --preview-window=down:3:wrap
 
 # give a preview of directory by exa when completing cd
-zstyle ':fzf-tab:complete:cd:*' extra-opts --preview=$extract'exa -1 --color=always $realpath'
+zstyle ':fzf-tab:complete:cd:*' extra-opts --preview=$fzf_tab_preview_init'exa -1 --color=always $realpath'
 ```
 
 fzf-tab is configured via command like this: `zstyle ':fzf-tab:{context}' tag value`. `fzf-tab` is the top context.

--- a/README.md
+++ b/README.md
@@ -117,17 +117,18 @@ zstyle ':completion:complete:*:options' sort false
 # use input as query string when completing zlua
 zstyle ':fzf-tab:complete:_zlua:*' query-string input
 
-# `$fzf_tab_preview_init` contains some boilerplate code to init some useful variables:
-# $in       - what you select
-# $group    - the group name of what you select
-# $realpath - use this if what you select is a file name or path
-
 # give a preview of commandline arguments when completing `kill`
 zstyle ':completion:*:*:*:*:processes' command "ps -u $USER -o pid,user,comm,cmd -w -w"
-zstyle ':fzf-tab:complete:kill:argument-rest' extra-opts --preview=$fzf_tab_preview_init'ps --pid=$in[(w)1] -o cmd --no-headers -w -w' --preview-window=down:3:wrap
+zstyle ':fzf-tab:complete:kill:argument-rest' extra-opts --preview=$fzf_tab_preview_init'ps --pid=$word -o cmd --no-headers -w -w' --preview-window=down:3:wrap
 
 # give a preview of directory by exa when completing cd
 zstyle ':fzf-tab:complete:cd:*' extra-opts --preview=$fzf_tab_preview_init'exa -1 --color=always $realpath'
+
+# NOTE: `$fzf_tab_preview_init` contains some boilerplate code to init some useful variables:
+# $word     - the actual word to insert
+# $desc     - the description of the word, this is what you see
+# $group    - the group name of what you select
+# $realpath - use this if what you select is a file name or path
 ```
 
 fzf-tab is configured via command like this: `zstyle ':fzf-tab:{context}' tag value`. `fzf-tab` is the top context.

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -14,18 +14,18 @@ FZF_TAB_HOME=${0:h}
 
 source ${0:h}/lib/zsh-ls-colors/ls-colors.zsh fzf-tab-lscolors
 
-typeset -g fzf_tab_preview_init=$'
+typeset -g fzf_tab_preview_init="
 # trim input
-local in=${${"$(<{f})"%$\'\\0\'*}#*$\'\\0\'*$\'\\0\'}
+local in=\${\${\"\$(<{f})\"%\$'\0'*}#*\$'\0'*\$'\0'}
 # get ctxt for current completion
-local -A ctxt=("${(@ps:\\2:)CTXT}")
+local -A ctxt=(\"\${(@ps:\2:)CTXT}\")
 # get group
-local -a groups=("${(@ps:\\2:)GROUPS}")
-local -i gid=${"$(<{f})"%%$\'\\0\'*}
-local group=$groups[gid]
+local -a groups=(\"\${(@ps:\2:)GROUPS}\")
+local -i gid=\${\"\$(<{f})\"%%\$'\0'*}
+local group=\$groups[gid]
 # real path
-local realpath=${(Qe)~${:-${ctxt[IPREFIX]}${ctxt[hpre]}}}${(Q)in}
-'
+local realpath=\${(Qe)~\${:-\${ctxt[IPREFIX]}\${ctxt[hpre]}}}\${(Q)in}
+"
 
 _fzf_tab_debug() {
   echo -E $'\n'${(qqqq)1}$'\n'

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -24,8 +24,7 @@ local desc=\${\${\"\$(<{f})\"%\$'\0'*}#*\$'\0'}
 # get ctxt for current completion
 local -A ctxt=(\"\${(@0)\${_fzf_tab_compcap[(r)\${(b)desc}\$bs*]#*\$bs}}\")
 # get group
-local -i gid=\${\"\$(<{f})\"%%\$'\0'*}
-local group=\$_fzf_tab_groups[gid]
+local group=\$_fzf_tab_groups[\$ctxt[group]]
 # get real path if it is file
 if (( \$+ctxt[isfile] )); then
   local realpath=\${(Qe)~\${:-\${ctxt[IPREFIX]}\${ctxt[hpre]}}}\${(Q)desc}

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -14,6 +14,20 @@ FZF_TAB_HOME=${0:h}
 
 source ${0:h}/lib/zsh-ls-colors/ls-colors.zsh fzf-tab-lscolors
 
+typeset -g fzf_tab_preview_init="
+# trim input
+local in=\${\${\"\$(<{f})\"%\$'\0'*}#*\$'\0'*\$'\0'}
+# get ctxt for current completion
+local -A ctxt=(\"\${(@ps:\2:)CTXT}\")
+# get group
+local -a groups=(\"\${(@ps:\2:)GROUPS}\")
+local -i gid=\${\"\$(<{f})\"%%\$'\0'*}
+local group=\$groups[gid]
+# real path
+local realpath=\${ctxt[IPREFIX]}\${ctxt[hpre]}\$in
+realpath=\${(Qe)~realpath}
+"
+
 _fzf_tab_debug() {
   echo -E $'\n'${(qqqq)1}$'\n'
 }

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -247,7 +247,7 @@ _fzf_tab_get_headers() {
             len+=$mlen
         fi
     done
-    (( $#tmp )) && headers+=$tmp
+    (( $#tmp )) && headers+=0$'\0'$tmp
 }
 
 _fzf_tab_colorize() {

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -442,6 +442,8 @@ _fzf_tab_complete() {
             [[ -d /tmp/fzf-tab ]] || mkdir -p /tmp/fzf-tab
             echo -E ${(pj:\n:)_fzf_tab_compcap} > /tmp/fzf-tab/compcap.$$
             echo -E ${(pj:\n:)_fzf_tab_groups} > /tmp/fzf-tab/groups.$$
+            # TODO: this is deprecated and should be removed in the future
+            export CTXT=${${_fzf_tab_compcap[1]#*$'\2'}//$'\0'/$'\2'}
 
             if (( $#headers )); then
                 choices=$(${(eX)command} $opts <<<${(pj:\n:)headers} <<<${(pj:\n:)candidates})

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -14,18 +14,18 @@ FZF_TAB_HOME=${0:h}
 
 source ${0:h}/lib/zsh-ls-colors/ls-colors.zsh fzf-tab-lscolors
 
-typeset -g fzf_tab_preview_init="
+typeset -g fzf_tab_preview_init=$'
 # trim input
-local in=\${\${\"\$(<{f})\"%\$'\0'*}#*\$'\0'*\$'\0'}
+local in=${${"$(<{f})"%$\'\\0\'*}#*$\'\\0\'*$\'\\0\'}
 # get ctxt for current completion
-local -A ctxt=(\"\${(@ps:\2:)CTXT}\")
+local -A ctxt=("${(@ps:\\2:)CTXT}")
 # get group
-local -a groups=(\"\${(@ps:\2:)GROUPS}\")
-local -i gid=\${\"\$(<{f})\"%%\$'\0'*}
-local group=\$groups[gid]
+local -a groups=("${(@ps:\\2:)GROUPS}")
+local -i gid=${"$(<{f})"%%$\'\\0\'*}
+local group=$groups[gid]
 # real path
-local realpath=\${(Qe)~\${:-\${ctxt[IPREFIX]}\${ctxt[hpre]}}}\${(Q)in}
-"
+local realpath=${(Qe)~${:-${ctxt[IPREFIX]}${ctxt[hpre]}}}${(Q)in}
+'
 
 _fzf_tab_debug() {
   echo -E $'\n'${(qqqq)1}$'\n'

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -24,8 +24,7 @@ local -a groups=(\"\${(@ps:\2:)GROUPS}\")
 local -i gid=\${\"\$(<{f})\"%%\$'\0'*}
 local group=\$groups[gid]
 # real path
-local realpath=\${ctxt[IPREFIX]}\${ctxt[hpre]}\$in
-realpath=\${(Qe)~realpath}
+local realpath=\${(Qe)~\${:-\${ctxt[IPREFIX]}\${ctxt[hpre]}}}\${(Q)in}
 "
 
 _fzf_tab_debug() {

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -14,6 +14,10 @@ FZF_TAB_HOME=${0:h}
 
 source ${0:h}/lib/zsh-ls-colors/ls-colors.zsh fzf-tab-lscolors
 
+_fzf_tab_debug() {
+  echo -E $'\n'${(qqqq)1}$'\n'
+}
+
 # thanks Valodim/zsh-capture-completion
 _fzf_tab_compadd() {
     # parse all options
@@ -114,7 +118,7 @@ _check_fzf_tab_opts || FZF_TAB_COMMAND=(
     --ansi   # Enable ANSI color support, necessary for showing groups
     --expect='$continuous_trigger,$print_query' # For continuous completion
     '--color=hl:$(( $#headers == 0 ? 108 : 255 ))'
-    --nth=2,3 --delimiter='\x00'  # Don't search prefix
+    --with-nth=2,3,4 --nth=2,3 --delimiter='\x00'  # Don't search prefix
     --layout=reverse --height='${FZF_TMUX_HEIGHT:=75%}'
     --tiebreak=begin -m --bind=tab:down,btab:up,change:top,ctrl-space:toggle --cycle
     '--query=$query'   # $query will be expanded to query string at runtime.
@@ -217,12 +221,12 @@ _fzf_tab_get_headers() {
         [[ $_fzf_tab_groups[i] == "__hide__"* ]] && continue
 
         if (( len + $#_fzf_tab_groups[i] > COLUMNS - 5 )); then
-            headers+=$tmp
+            headers+=0$'\0'$tmp
             tmp='' && len=0
         fi
         if (( len + mlen > COLUMNS - 5 )); then
             # the last column doesn't need padding
-            headers+=$tmp$group_colors[i]$_fzf_tab_groups[i]$'\033[00m'
+            headers+=0$'\0'$tmp$group_colors[i]$_fzf_tab_groups[i]$'\033[00m'
             tmp='' && len=0
         else
             tmp+=$group_colors[i]${(r:$mlen:)_fzf_tab_groups[i]}$'\033[00m'
@@ -334,9 +338,9 @@ _fzf_tab_get_candidates() {
             local color=$group_colors[$v[group]]
             # add a hidden group index at start of string to keep group order when sorting
             # first group index is for builtin sort, sencond is for GNU sort
-            tcandidates+=$v[group]$'\b'$color$prefix$dpre$'\0'$v[group]$'\b'$k$'\0'$dsuf
+            tcandidates+=$v[group]$'\0'$color$prefix$dpre$'\0'$v[group]$'\b'$k$'\0'$dsuf
         else
-            tcandidates+=$no_group_color$dpre$'\0'$k$'\0'$dsuf
+            tcandidates+=0$'\0'$no_group_color$dpre$'\0'$k$'\0'$dsuf
         fi
 
         # check group with duplicate member
@@ -416,6 +420,7 @@ _fzf_tab_complete() {
             _fzf_tab_get -a extra-opts opts
 
             export CTXT=${${_fzf_tab_compcap[1]#*$'\2'}//$'\0'/$'\2'}
+            export GROUPS=${(pj:\2:)_fzf_tab_groups}
 
             if (( $#headers )); then
                 choices=$(${(eX)command} $opts <<<${(pj:\n:)headers} <<<${(pj:\n:)candidates})
@@ -444,7 +449,7 @@ _fzf_tab_complete() {
             fi
             choices[1]=()
 
-            choices=("${(@)${(@)choices%$nul*}#*$nul}")
+            choices=("${(@)${(@)choices%$nul*}#[0-9]#$nul*$nul}")
 
             unset CTXT
             ;;
@@ -456,7 +461,7 @@ _fzf_tab_complete() {
     choices[1]=()
 
     for choice in "$choices[@]"; do
-        local -A v=("${(@0)${_fzf_tab_compcap[(r)${(b)choice}$bs*]#*$bs}}")
+        local -A v=("${(@0)${_fzf_tab_compcap[(r)${(b)choice#[0-9]#$nul}$bs*]#*$bs}}")
         local -a args=("${(@ps:\1:)v[args]}")
         [[ -z $args[1] ]] && args=()  # don't pass an empty string
         IPREFIX=$v[IPREFIX] PREFIX=$v[PREFIX] SUFFIX=$v[SUFFIX] ISUFFIX=$v[ISUFFIX]


### PR DESCRIPTION
This will close #79.

Example:

```zsh
zstyle ':fzf-tab:complete:*' extra-opts --preview=$fzf_tab_preview_init'
echo word: $word
echo description: $desc
echo group: $group
if (( $+ctxt[isfile] )); then
  echo path: $realpath
fi
'
```
