### PR TITLE
wip: improve completion description

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -361,7 +361,7 @@ _fzf_tab_get_candidates() {
         # add character and color to describe the type of the files
         dsuf='' dpre=''
         if (( $+v[isfile] )); then
-            filepath=${v[IPREFIX]}${v[hpre]}${k#*$'\b'}
+            filepath=${v[IPREFIX]}${v[hpre]}$v[word]
             filepath=${(Q)${(e)~filepath}}
             if (( $#list_colors && $+builtins[fzf-tab-colorize] )); then
               fzf-tab-colorize $filepath 2>/dev/null

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -91,6 +91,12 @@ _fzf_tab_compadd() {
     _opts+=("${(@kv)apre}" "${(@kv)hpre}" $isfile)
     __tmp_value+=$'\0args\0'${(pj:\1:)_opts}
 
+
+    group=$expl
+    groupid=$_fzf_tab_groups[(ie)$expl]
+
+    fzf_tab_compadd_hook
+
     # dscr - the string to show to users
     # example dscr:
     # Folder/

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -14,35 +14,18 @@ FZF_TAB_HOME=${0:h}
 
 source ${0:h}/lib/zsh-ls-colors/ls-colors.zsh fzf-tab-lscolors
 
-# This is an attenmpt at escaping fully fzf_tab_preview_init
-# typeset -g fzf_tab_preview_init='
-# # TODO once the dscr changed with the icon the $in variable in fzf preview has the icon in front,
-# # we need to provide hit, description, group to fzf_tab_preview_init
-# # trim input
-# local in=${${"$(<{f})\\"%$\\"\\0\\"*}#*$\\"\\0\\"*$\\"\\0\\"}
-# # get ctxt for current completion
-# local -A ctxt=("${(@ps:2:)CTXT}")
-# # get group
-# local -a groups=("${(@ps:2:)GROUPS}")
-# local -i gid=${"$(<{f})"%%$\\"\\0\\"*}
-# local group=$groups[gid]
-# # real path
-# local realpath=${ctxt[IPREFIX]}${ctxt[hpre]}$word
-# realpath=${(Qe)~realpath}
-# '
-
-typeset -g fzf_tab_preview_init="
+typeset -g fzf_tab_preview_init=$'
 # trim input
-local in=\${\${\"\$(<{f})\"%\$'\0'*}#*\$'\0'*\$'\0'}
+local in=${${"$(<{f})"%$\'\\0\'*}#*$\'\\0\'*$\'\\0\'}
 # get ctxt for current completion
-local -A ctxt=(\"\${(@ps:\2:)CTXT}\")
+local -A ctxt=("${(@ps:\\2:)CTXT}")
 # get group
-local -a groups=(\"\${(@ps:\2:)GROUPS}\")
-local -i gid=\${\"\$(<{f})\"%%\$'\0'*}
-local group=\$groups[gid]
+local -a groups=("${(@ps:\\2:)GROUPS}")
+local -i gid=${"$(<{f})"%%$\'\\0\'*}
+local group=$groups[gid]
 # real path
-local realpath=\${(Qe)~\${:-\${ctxt[IPREFIX]}\${ctxt[hpre]}}}\${(Q)in}
-"
+local realpath=${(Qe)~${:-${ctxt[IPREFIX]}${ctxt[hpre]}}}${(Q)in}
+'
 
 _fzf_tab_debug() {
   echo -E $'\n'${(qqqq)1}$'\n'

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -80,6 +80,8 @@ _fzf_tab_compadd() {
     _opts+=("${(@kv)apre}" "${(@kv)hpre}" $isfile)
     __tmp_value+=$'\0args\0'${(pj:\1:)_opts}
 
+    # Hook defined by user to alter the description of the completion
+    fzf_tab_compadd_hook
 
     # dscr - the string to show to users
     # example dscr:
@@ -98,9 +100,6 @@ _fzf_tab_compadd() {
         elif [[ -n $word ]]; then
             dscr=$word
         fi
-
-        # Hook defined by user to alter the description of the completion
-        fzf_tab_compadd_hook
 
         _fzf_tab_compcap+=$dscr$'\2'$__tmp_value${word:+$'\0word\0'$word}
     done

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -14,7 +14,18 @@ FZF_TAB_HOME=${0:h}
 
 source ${0:h}/lib/zsh-ls-colors/ls-colors.zsh fzf-tab-lscolors
 
+# TODO once the dscr changed with the icon the $in variable in fzf preview has the icon in front,
+#
+# > echo $in 
+#  copy_from_zsh_src.zsh
+#
+# how to get $word and $dscr in fzf preview
 typeset -g fzf_tab_preview_init="
+# TODO dscr
+local dscr=\${\${\"\$(<{f})\"%\$'\0'*}#*\$'\0'*\$'\0'}
+# TODO word
+local word=\${\${\"\$(<{f})\"%\$'\0'*}#*\$'\0'*\$'\0'}
+
 # trim input
 local in=\${\${\"\$(<{f})\"%\$'\0'*}#*\$'\0'*\$'\0'}
 # get ctxt for current completion
@@ -81,8 +92,13 @@ _fzf_tab_compadd() {
     __tmp_value+=$'\0args\0'${(pj:\1:)_opts}
 
     # dscr - the string to show to users
+    # example dscr:
+    # Folder/
     # word - the string to be inserted
+    # example word:
+    # Documents/Folder/
     local dscr word i
+    
     for i in {1..$#__hits}; do
         word=$__hits[i] dscr=$__dscr[i]
         if [[ -n $dscr ]]; then
@@ -90,7 +106,33 @@ _fzf_tab_compadd() {
         elif [[ -n $word ]]; then
             dscr=$word
         fi
+
+        # example __tmp_comcap:
+        # <>isfile-fgroup1args-Q-s-W-Mr:|/=* r:|=*-p-f
+        # <>isfile-fgroup1args-Q-s-W-Mr:|/=* r:|=*-p-f
+        local tmp_compcap=$dscr$'\2'$__tmp_value${word:+$'\0word\0'$word}
+
+
+        # TODO how to get groups?
+        # GROUPS seem unaccessible
+        groups=
+        # TODO how to get group id ?
+        # I dont think it is safe if there is numbers before group
+        local gid="${__tmp_value//[!0-9]/}"
+        # TODO how to get group name ?
+        local group=groups[gid]
+
+        # TODO do this the same way of fzf_tab_preview_init
+        # # Here will be the custom script injection for icons
+        # if [ "$fzf_tab_completion_description_init" ]
+        #   dscr=$(eval 'local $dscr'$fzf_tab_completion_description_init)
+
+        # TODO remove this and use custom fzf_tab_completion_description_init above
+        dscr=$(echo "$dscr" | devicon-lookup)
+
+
         _fzf_tab_compcap+=$dscr$'\2'$__tmp_value${word:+$'\0word\0'$word}
+        # echo $_fzf_tab_compcap
     done
 
     # tell zsh that the match is successful

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -24,14 +24,14 @@ local desc=\${\${\"\$(<{f})\"%\$'\0'*}#*\$'\0'}
 # get ctxt for current completion
 local -A ctxt=(\"\${(@0)\${_fzf_tab_compcap[(r)\${(b)desc}\$bs*]#*\$bs}}\")
 # get group
-local -i gid=\${\"\$(<{f})\"%%\$'\0'*}
+local -i gid=\$ctxt[group]
 local group=\$_fzf_tab_groups[gid]
-# get real path if it is file
-if (( \$+ctxt[isfile] )); then
-  local realpath=\${(Qe)~\${:-\${ctxt[IPREFIX]}\${ctxt[hpre]}}}\${(Q)desc}
-fi
 # get original word
 local word=\$ctxt[word]
+# get real path if it is file
+if (( \$+ctxt[isfile] )); then
+  local realpath=\${(Qe)~\${:-\${ctxt[IPREFIX]}\${ctxt[hpre]}}}\$word
+fi
 "
 
 _fzf_tab_debug() {


### PR DESCRIPTION
This pr aim to have a way to customize the description field
![image](https://user-images.githubusercontent.com/23508913/96393879-c6b3d780-11c0-11eb-9535-d64486068e5c.png)

There is a lot of problem that I do not manage to resolve due to zsh-ing code, maybe you can give an helping hand, 
I wrote all the TODO inside the code for context
```zsh
# TODO once the dscr changed with the icon the $in variable in fzf preview has the icon in front,
#
# > echo $in 
#  copy_from_zsh_src.zsh
#
# how to get $word and $dscr in fzf preview
typeset -g fzf_tab_preview_init="
# TODO dscr
local dscr=\${\${\"\$(<{f})\"%\$'\0'*}#*\$'\0'*\$'\0'}
# TODO word
local word=\${\${\"\$(<{f})\"%\$'\0'*}#*\$'\0'*\$'\0'}
```


```zsh
# TODO how to get groups?
# GROUPS seem unaccessible
groups=
# TODO how to get group id ?
# I dont think it is safe if there is numbers before group
local gid="${__tmp_value//[!0-9]/}"
# TODO how to get group name ?
local group=groups[gid]

# TODO do this the same way of fzf_tab_preview_init
# # Here will be the custom script injection for icons
# if [ "$fzf_tab_completion_description_init" ]
#   dscr=$(eval 'local $dscr'$fzf_tab_completion_description_init)

# TODO remove this and use custom fzf_tab_completion_description_init above
dscr=$(echo "$dscr" | devicon-lookup)

```