### PR TITLE
feat: add support for tmux popup

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -148,6 +148,7 @@ _fzf_tab_get() {
     _fzf_tab_add_default group-colors $FZF_TAB_GROUP_COLORS
     _fzf_tab_add_default ignore false
     _fzf_tab_add_default print-query alt-enter
+    _fzf_tab_add_default popup-pad 0 0
 
     if zstyle -m ':completion:*:descriptions' format '*'; then
         _fzf_tab_add_default prefix '·'

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -12,6 +12,7 @@ zmodload -F zsh/stat b:zstat
 0="${${(M)0:#/*}:-$PWD/$0}"
 FZF_TAB_HOME=${0:h}
 
+autoload -Uz $FZF_TAB_HOME/fzf-tmux-popup
 source ${0:h}/lib/zsh-ls-colors/ls-colors.zsh fzf-tab-lscolors
 
 # thanks Valodim/zsh-capture-completion

--- a/fzf-tmux-popup
+++ b/fzf-tmux-popup
@@ -1,4 +1,5 @@
-#!/usr/bin/env zsh
+#!/hint/zsh
+emulate -L zsh -o extended_glob
 
 local -a fzf_opts=($@)
 fzf_opts=(${${fzf_opts/--height*}/--layout*})
@@ -14,7 +15,16 @@ cat > /tmp/fzf-tab/list-$$
 
 # get the size of content, note we should remove all ANSI color code
 local comp_lines=${#${(f)"$(</tmp/fzf-tab/list-$$)"}}
-local comp_length=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/fzf-tab/list-$$ | awk 'length > max_length { max_length = length; } END { print max_length }')
+# FIXME: can't get the correct width of CJK characters.
+if (( comp_lines <= 500 )); then
+  local comp_length=0 length
+  for line in ${(f)"$(</tmp/fzf-tab/list-$$)"}; do
+    length=${#${(S)line//$'\x1b['[0-9]#*m}}
+    (( length >= comp_length )) && comp_length=$length
+  done
+else
+  local comp_length=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/fzf-tab/list-$$ | awk 'length > max_length { max_length = length; } END { print max_length }')
+fi
 
 # calculate the popup height and y position
 if (( cursor_y * 2 > window_height )); then
@@ -29,14 +39,14 @@ else
 fi
 
 # calculate the popup width and x position
-local popup_width=$(( comp_length + 4 > window_width ? window_width : comp_length + 4 ))
+local popup_width=$(( comp_length + 5 > window_width ? window_width : comp_length + 5 ))
 local popup_x=$(( cursor_x + popup_width > window_width ? window_width - popup_width : cursor_x ))
 
 echo -E "fzf ${(qq)fzf_opts[@]} < /tmp/fzf-tab/list-$$ > /tmp/fzf-tab/result-$$" > /tmp/fzf-tab/fzf-$$
 {
   tmux popup -x $popup_x -y $popup_y \
        -w $popup_width -h $popup_height \
-       -KE -R "zsh -f /tmp/fzf-tab/fzf-$$"
+       -KE -R "source /tmp/fzf-tab/fzf-$$"
   cat /tmp/fzf-tab/result-$$
 } always {
   rm /tmp/fzf-tab/*-$$

--- a/fzf-tmux-popup
+++ b/fzf-tmux-popup
@@ -13,10 +13,12 @@ local cursor_y=$((tmp[1] + tmp[2])) cursor_x=$((tmp[3] + tmp[4])) window_height=
 touch /tmp/fzf-tab/result-$$
 cat > /tmp/fzf-tab/list-$$
 
-local text REPLY comp_lines comp_length length
+local text REPLY comp_lines comp_length length popup_pad
+
+zstyle -a ":fzf-tab:$_fzf_tab_curcontext" popup-pad popup_pad
 
 # get the size of content, note we should remove all ANSI color code
-comp_lines=${#${(f)"$(</tmp/fzf-tab/list-$$)"}}
+comp_lines=$(( ${#${(f)"$(</tmp/fzf-tab/list-$$)"}} + ${popup_pad[(w)2]:-0} ))
 # FIXME: can't get the correct width of CJK characters.
 if (( comp_lines <= 500 )); then
   comp_length=0
@@ -27,6 +29,7 @@ if (( comp_lines <= 500 )); then
 else
   comp_length=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/fzf-tab/list-$$ | awk 'length > max_length { max_length = length; } END { print max_length }')
 fi
+comp_length=$(( comp_length + ${popup_pad[(w)1]:-0} ))
 
 local popup_height popup_y popup_width popup_x
 

--- a/fzf-tmux-popup
+++ b/fzf-tmux-popup
@@ -8,39 +8,43 @@ fzf_opts=(${${fzf_opts/--height*}/--layout*})
 local -a tmp=($(tmux display-message -p "#{pane_top} #{cursor_y} #{pane_left} #{cursor_x} #{window_height} #{window_width}"))
 local cursor_y=$((tmp[1] + tmp[2])) cursor_x=$((tmp[3] + tmp[4])) window_height=$tmp[5] window_width=$tmp[6]
 
-# create fifo and write to completion lists to file
+# write completion list to file
 [[ -d /tmp/fzf-tab ]] || mkdir /tmp/fzf-tab
 touch /tmp/fzf-tab/result-$$
 cat > /tmp/fzf-tab/list-$$
 
+local text REPLY comp_lines comp_length length
+
 # get the size of content, note we should remove all ANSI color code
-local comp_lines=${#${(f)"$(</tmp/fzf-tab/list-$$)"}}
+comp_lines=${#${(f)"$(</tmp/fzf-tab/list-$$)"}}
 # FIXME: can't get the correct width of CJK characters.
 if (( comp_lines <= 500 )); then
-  local comp_length=0 length
+  comp_length=0
   for line in ${(f)"$(</tmp/fzf-tab/list-$$)"}; do
     length=${#${(S)line//$'\x1b['[0-9]#*m}}
     (( length >= comp_length )) && comp_length=$length
   done
 else
-  local comp_length=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/fzf-tab/list-$$ | awk 'length > max_length { max_length = length; } END { print max_length }')
+  comp_length=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/fzf-tab/list-$$ | awk 'length > max_length { max_length = length; } END { print max_length }')
 fi
+
+local popup_height popup_y popup_width popup_x
 
 # calculate the popup height and y position
 if (( cursor_y * 2 > window_height )); then
   # show above the cursor
-  local popup_height=$(( comp_lines >= cursor_y ? cursor_y : comp_lines + 4 ))
-  local popup_y=$cursor_y
+  popup_height=$(( comp_lines >= cursor_y ? cursor_y : comp_lines + 4 ))
+  popup_y=$cursor_y
 else
   # show below the cursor
-  local popup_height=$(( comp_lines >= (window_height - cursor_y) ? window_height - cursor_y : comp_lines + 4 ))
-  local popup_y=$(( cursor_y + popup_height + 1 ))
+  popup_height=$(( comp_lines >= (window_height - cursor_y) ? window_height - cursor_y : comp_lines + 4 ))
+  popup_y=$(( cursor_y + popup_height + 1 ))
   fzf_opts+=(--layout=reverse)
 fi
 
 # calculate the popup width and x position
-local popup_width=$(( comp_length + 5 > window_width ? window_width : comp_length + 5 ))
-local popup_x=$(( cursor_x + popup_width > window_width ? window_width - popup_width : cursor_x ))
+popup_width=$(( comp_length + 5 > window_width ? window_width : comp_length + 5 ))
+popup_x=$(( cursor_x + popup_width > window_width ? window_width - popup_width : cursor_x ))
 
 echo -E "fzf ${(qq)fzf_opts[@]} < /tmp/fzf-tab/list-$$ > /tmp/fzf-tab/result-$$" > /tmp/fzf-tab/fzf-$$
 {

--- a/fzf-tmux-popup.zsh
+++ b/fzf-tmux-popup.zsh
@@ -28,8 +28,8 @@ else
 fi
 
 # calculate the popup width and x position
-local popup_x=$cursor_x
-local popup_width=$(( comp_length >= (window_width - cursor_x) ? window_width - curosr_x : comp_length + 4 ))
+local popup_width=$(( comp_length + 4 > window_width ? window_width : comp_length + 4 ))
+local popup_x=$(( cursor_x + popup_width > window_width ? window_width - popup_width : cursor_x ))
 
 echo -E "fzf ${(qq)fzf_opts[@]} < /tmp/fzf-tab-list-$$ > /tmp/fzf-tab-$$"  > /tmp/fzf-tab-tmux.zsh
 {

--- a/fzf-tmux-popup.zsh
+++ b/fzf-tmux-popup.zsh
@@ -18,11 +18,11 @@ local comp_length=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/fzf-tab-list-$$ | awk 'length
 # calculate the popup height and y position
 if (( cursor_y * 2 > window_height )); then
   # show above the cursor
-  local popup_height=$(( comp_lines >= cursor_y ? cursor_y : comp_lines ))
+  local popup_height=$(( comp_lines >= cursor_y ? cursor_y : comp_lines + 4 ))
   local popup_y=$cursor_y
 else
   # show below the cursor
-  local popup_height=$(( comp_lines >= (window_height - cursor_y) ? window_height - cursor_y : comp_lines + 3 ))
+  local popup_height=$(( comp_lines >= (window_height - cursor_y) ? window_height - cursor_y : comp_lines + 4 ))
   local popup_y=$(( cursor_y + popup_height + 1 ))
   fzf_opts+=(--layout=reverse)
 fi
@@ -34,7 +34,7 @@ local popup_width=$(( comp_length >= (window_width - cursor_x) ? window_width - 
 echo -E "fzf ${(qq)fzf_opts[@]} < /tmp/fzf-tab-list-$$ > /tmp/fzf-tab-$$"  > /tmp/fzf-tab-tmux.zsh
 {
   tmux popup -x $popup_x -y $popup_y \
-       -w $((popup_width * 100 / window_width))% -h $((popup_height * 100 / window_height))% \
+       -w $popup_width -h $popup_height \
        -KE -R "zsh /tmp/fzf-tab-tmux.zsh"
   cat /tmp/fzf-tab-$$
 } always {

--- a/fzf-tmux-popup.zsh
+++ b/fzf-tmux-popup.zsh
@@ -1,0 +1,10 @@
+#!/usr/bin/env zsh
+
+mkfifo /tmp/fzf-tab-$$
+
+cat > /tmp/fzf-tab-list-$$
+
+tmux popup -KE -R "fzf $1 < /tmp/fzf-tab-list-$$ > /tmp/fzf-tab-$$" &
+
+cat /tmp/fzf-tab-$$
+

--- a/fzf-tmux-popup.zsh
+++ b/fzf-tmux-popup.zsh
@@ -1,10 +1,49 @@
 #!/usr/bin/env zsh
 
-mkfifo /tmp/fzf-tab-$$
+local -a fzf_opts=($@)
+fzf_opts=(${${fzf_opts/--height*}/--layout*})
 
+# get position of cursor and size of window
+local -a tmp=($(tmux display-message -p "#{pane_top} #{cursor_y} #{pane_left} #{cursor_x} #{window_height} #{window_width}"))
+local cursor_y=$((tmp[1] + tmp[2])) cursor_x=$((tmp[3] + tmp[4])) window_height=$tmp[5] window_width=$tmp[6]
+
+# create fifo and write to completion lists to file
+mkfifo /tmp/fzf-tab-$$
 cat > /tmp/fzf-tab-list-$$
 
-tmux popup -w80% -h50% -KE -R "fzf $1 < /tmp/fzf-tab-list-$$ > /tmp/fzf-tab-$$" &
+# get the size of content, note we should remove all ANSI color code
+local comp_lines=${#${(f)"$(</tmp/fzf-tab-list-$$)"}}
+local comp_length=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/fzf-tab-list-$$ | awk 'length > max_length { max_length = length; } END { print max_length }')
 
-cat /tmp/fzf-tab-$$
+# calculate the popup height and y position
+if (( comp_lines + 4 > window_height - cursor_y )); then
+  local popup_y=$cursor_y
+else
+  local popup_y=$(( cursor_y + comp_lines + 5 ))
+  fzf_opts+=(--layout=reverse)
+fi
+local max_popup_height=$(( 20 * 100 / window_height + 3 ))
+if (( comp_lines >= window_height )); then
+  local popup_height=$(( cursor_y * 100 / window_height + 3 ))
+else
+  local popup_height=$(( (comp_lines + 4) * 100 / window_height ))
+fi
+(( popup_height > max_popup_height )) && popup_height=$max_popup_height
 
+# calculate the popup width and x position
+local popup_x=$cursor_x
+if (( comp_length >= window_width )); then
+  local popup_width=$(( 100 - curosr_x * 100 / window_width ))
+else
+  local popup_width=$(( comp_length * 100 / window_width ))
+fi
+local popup_width=$(( 100 - curosr_x * 100 / window_width ))
+
+# zenity --info --text="$comp_lines . $comp_length . $window_height . $window_width . $popup_height% . $popup_width% | $fzf_opts"
+echo -E "fzf ${(qq)fzf_opts[@]} < /tmp/fzf-tab-list-$$ > /tmp/fzf-tab-$$"  > /tmp/fzf-tab-tmux.zsh
+{
+  tmux popup -x $popup_x -y $popup_y -w $popup_width% -h $popup_height% -KE -R "zsh /tmp/fzf-tab-tmux.zsh" &
+  cat /tmp/fzf-tab-$$
+} always {
+  rm /tmp/fzf-tab-$$ /tmp/fzf-tab-list-$$
+}

--- a/fzf-tmux-popup.zsh
+++ b/fzf-tmux-popup.zsh
@@ -8,7 +8,7 @@ local -a tmp=($(tmux display-message -p "#{pane_top} #{cursor_y} #{pane_left} #{
 local cursor_y=$((tmp[1] + tmp[2])) cursor_x=$((tmp[3] + tmp[4])) window_height=$tmp[5] window_width=$tmp[6]
 
 # create fifo and write to completion lists to file
-mkfifo /tmp/fzf-tab-$$
+touch /tmp/fzf-tab-$$
 cat > /tmp/fzf-tab-list-$$
 
 # get the size of content, note we should remove all ANSI color code
@@ -16,33 +16,26 @@ local comp_lines=${#${(f)"$(</tmp/fzf-tab-list-$$)"}}
 local comp_length=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/fzf-tab-list-$$ | awk 'length > max_length { max_length = length; } END { print max_length }')
 
 # calculate the popup height and y position
-if (( comp_lines + 4 > window_height - cursor_y )); then
+if (( cursor_y * 2 > window_height )); then
+  # show above the cursor
+  local popup_height=$(( comp_lines >= cursor_y ? cursor_y : comp_lines ))
   local popup_y=$cursor_y
 else
-  local popup_y=$(( cursor_y + comp_lines + 5 ))
+  # show below the cursor
+  local popup_height=$(( comp_lines >= (window_height - cursor_y) ? window_height - cursor_y : comp_lines + 3 ))
+  local popup_y=$(( cursor_y + popup_height + 1 ))
   fzf_opts+=(--layout=reverse)
 fi
-local max_popup_height=$(( 20 * 100 / window_height + 3 ))
-if (( comp_lines >= window_height )); then
-  local popup_height=$(( cursor_y * 100 / window_height + 3 ))
-else
-  local popup_height=$(( (comp_lines + 4) * 100 / window_height ))
-fi
-(( popup_height > max_popup_height )) && popup_height=$max_popup_height
 
 # calculate the popup width and x position
 local popup_x=$cursor_x
-if (( comp_length >= window_width )); then
-  local popup_width=$(( 100 - curosr_x * 100 / window_width ))
-else
-  local popup_width=$(( comp_length * 100 / window_width ))
-fi
-local popup_width=$(( 100 - curosr_x * 100 / window_width ))
+local popup_width=$(( comp_length >= (window_width - cursor_x) ? window_width - curosr_x : comp_length + 4 ))
 
-# zenity --info --text="$comp_lines . $comp_length . $window_height . $window_width . $popup_height% . $popup_width% | $fzf_opts"
 echo -E "fzf ${(qq)fzf_opts[@]} < /tmp/fzf-tab-list-$$ > /tmp/fzf-tab-$$"  > /tmp/fzf-tab-tmux.zsh
 {
-  tmux popup -x $popup_x -y $popup_y -w $popup_width% -h $popup_height% -KE -R "zsh /tmp/fzf-tab-tmux.zsh" &
+  tmux popup -x $popup_x -y $popup_y \
+       -w $((popup_width * 100 / window_width))% -h $((popup_height * 100 / window_height))% \
+       -KE -R "zsh /tmp/fzf-tab-tmux.zsh"
   cat /tmp/fzf-tab-$$
 } always {
   rm /tmp/fzf-tab-$$ /tmp/fzf-tab-list-$$

--- a/fzf-tmux-popup.zsh
+++ b/fzf-tmux-popup.zsh
@@ -4,7 +4,7 @@ mkfifo /tmp/fzf-tab-$$
 
 cat > /tmp/fzf-tab-list-$$
 
-tmux popup -KE -R "fzf $1 < /tmp/fzf-tab-list-$$ > /tmp/fzf-tab-$$" &
+tmux popup -w80% -h50% -KE -R "fzf $1 < /tmp/fzf-tab-list-$$ > /tmp/fzf-tab-$$" &
 
 cat /tmp/fzf-tab-$$
 

--- a/fzf-tmux-popup.zsh
+++ b/fzf-tmux-popup.zsh
@@ -8,12 +8,13 @@ local -a tmp=($(tmux display-message -p "#{pane_top} #{cursor_y} #{pane_left} #{
 local cursor_y=$((tmp[1] + tmp[2])) cursor_x=$((tmp[3] + tmp[4])) window_height=$tmp[5] window_width=$tmp[6]
 
 # create fifo and write to completion lists to file
-touch /tmp/fzf-tab-$$
-cat > /tmp/fzf-tab-list-$$
+[[ -d /tmp/fzf-tab ]] || mkdir /tmp/fzf-tab
+touch /tmp/fzf-tab/result-$$
+cat > /tmp/fzf-tab/list-$$
 
 # get the size of content, note we should remove all ANSI color code
-local comp_lines=${#${(f)"$(</tmp/fzf-tab-list-$$)"}}
-local comp_length=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/fzf-tab-list-$$ | awk 'length > max_length { max_length = length; } END { print max_length }')
+local comp_lines=${#${(f)"$(</tmp/fzf-tab/list-$$)"}}
+local comp_length=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/fzf-tab/list-$$ | awk 'length > max_length { max_length = length; } END { print max_length }')
 
 # calculate the popup height and y position
 if (( cursor_y * 2 > window_height )); then
@@ -31,12 +32,12 @@ fi
 local popup_width=$(( comp_length + 4 > window_width ? window_width : comp_length + 4 ))
 local popup_x=$(( cursor_x + popup_width > window_width ? window_width - popup_width : cursor_x ))
 
-echo -E "fzf ${(qq)fzf_opts[@]} < /tmp/fzf-tab-list-$$ > /tmp/fzf-tab-$$"  > /tmp/fzf-tab-tmux.zsh
+echo -E "fzf ${(qq)fzf_opts[@]} < /tmp/fzf-tab/list-$$ > /tmp/fzf-tab/result-$$" > /tmp/fzf-tab/fzf-$$
 {
   tmux popup -x $popup_x -y $popup_y \
        -w $popup_width -h $popup_height \
-       -KE -R "zsh /tmp/fzf-tab-tmux.zsh"
-  cat /tmp/fzf-tab-$$
+       -KE -R "zsh -f /tmp/fzf-tab/fzf-$$"
+  cat /tmp/fzf-tab/result-$$
 } always {
-  rm /tmp/fzf-tab-$$ /tmp/fzf-tab-list-$$
+  rm /tmp/fzf-tab/*-$$
 }


### PR DESCRIPTION
[![asciicast](https://asciinema.org/a/yiyBrosZ3OmgkNRJ3NLxObUe3.svg)](https://asciinema.org/a/yiyBrosZ3OmgkNRJ3NLxObUe3)



I love this. It won't push my prompt to the top of pane when the completion list is too long.

Close #128.

How to use (**need tmux 3.2!!**):

```zsh
FZF_TAB_COMMAND[1]=fzf-tmux-popup
zstyle ':fzf-tab:*' command $FZF_TAB_COMMAND
```