### PR TITLE
fix: realpath using word instead of description

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,74 @@ If it is a number, then fzf-tab won't be activated if the number of candidates i
 
 Default value: `zstyle ':fzf-tab:*' ignore false`
 
+### compadd-hook
+
+You can hook on completion value and improve it using `fzf_tab_compadd_hook` 
+
+For example to add a lot of icons on many completions (Nerd icons patched fonts)
+
+```zsh
+fzf_tab_compadd_hook() {
+  # $expl - explicit group name
+  # $__hits - list of orginal completions
+  # $__dscr - list of transformed and described completions
+  # $PREFIX - text that already got completed before
+  case $_fzf_tab_curcontext in
+    # (systemctl-*)
+    # All context
+    (*)
+    # Line by line icon assignements
+    for i in {1..$#__hits}; do
+      word=$__hits[i] dscr=$__dscr[i]
+      if [[ -n $dscr ]]; then
+        dscr=${dscr//$'\n'}
+      elif [[ -n $word ]]; then
+        dscr=$word
+      fi
+
+      # absolute expanded path of a file
+      realpath="$(eval echo "${PREFIX}$word")"
+
+      case "$expl" in
+        (parameter) icon="$" ;;
+        (function) icon="ƒ" ;;
+        (alias) icon="Ą" ;;
+        (*branch*) icon="" ;;
+        (*command*) icon="" ;;
+        (*target*) icon="" ;;
+        (commit tag) icon="" ;;
+        (*commit*) icon="" ;;
+        (*file*) 
+          if [ -d $realpath ]; then
+            icon=""
+          else
+            icon="${$(echo "$word" | devicon-lookup):0:1}"
+          fi
+          # Only work inside a git directory
+          # [ -d .git ] && echo .git || git rev-parse --git-dir > /dev/null 2>&1
+          # icon="$icon ${$( git status --short "$realpath"):0:2}"
+          ;;
+        (*local*) icon="" ;;
+        (*remote*) icon="" ;;
+        (*head*) icon="ﰛ" ;;
+        (*option*)
+          case $word in
+            (*rm*|*delete**remove*)
+              icon=" " ;;
+            (*help) icon="" ;; # icon=" " icon=" " icon=""
+            (*) icon="" ;; # icon=" "
+          esac
+          ;;
+        (*) icon="" ;;
+      esac
+      icon="$icon "
+      __dscr[i]="$icon $dscr"
+    done
+    ;;
+esac
+}
+```
+
 ### fake-compadd
 
 How to do a fake compadd. This only affects the result of multiple selections.

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -24,13 +24,14 @@ local desc=\${\${\"\$(<{f})\"%\$'\0'*}#*\$'\0'}
 # get ctxt for current completion
 local -A ctxt=(\"\${(@0)\${_fzf_tab_compcap[(r)\${(b)desc}\$bs*]#*\$bs}}\")
 # get group
-local group=\$_fzf_tab_groups[\$ctxt[group]]
-# get real path if it is file
-if (( \$+ctxt[isfile] )); then
-  local realpath=\${(Qe)~\${:-\${ctxt[IPREFIX]}\${ctxt[hpre]}}}\${(Q)desc}
-fi
+local gid=\$ctxt[group]
+local group=\$_fzf_tab_groups[gid]
 # get original word
 local word=\$ctxt[word]
+# get real path if it is file
+if (( \$+ctxt[isfile] )); then
+  local realpath=\${(Qe)~\${:-\${ctxt[IPREFIX]}\${ctxt[hpre]}}}\$word
+fi
 "
 
 _fzf_tab_debug() {
@@ -88,6 +89,9 @@ _fzf_tab_compadd() {
     fi
     _opts+=("${(@kv)apre}" "${(@kv)hpre}" $isfile)
     __tmp_value+=$'\0args\0'${(pj:\1:)_opts}
+
+    # Hook defined by user to alter the description of the completion
+    fzf_tab_compadd_hook
 
     # dscr - the string to show to users
     # word - the string to be inserted

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -91,7 +91,9 @@ _fzf_tab_compadd() {
     __tmp_value+=$'\0args\0'${(pj:\1:)_opts}
 
     # Hook defined by user to alter the description of the completion
-    fzf_tab_compadd_hook
+    if typeset -f fzf_tab_compadd_hook > /dev/null; then
+      fzf_tab_compadd_hook
+    fi
 
     # dscr - the string to show to users
     # word - the string to be inserted


### PR DESCRIPTION
Following #127

This add an hook to be able to enrich the description of completion
![image](https://user-images.githubusercontent.com/23508913/97070659-6666d080-15da-11eb-9bce-4fa323f7f7cb.png)
![image](https://user-images.githubusercontent.com/23508913/97070661-741c5600-15da-11eb-84a5-f486228e37e4.png)
Git status
![image](https://user-images.githubusercontent.com/23508913/97070688-b0e84d00-15da-11eb-8d33-cb41bfcebfb2.png)

## What is left to do
- [ ] How to set custom color ? it seem that if set in `$__dscr` they get escaped no matter what