### PR TITLE
Use command rm when possible

### DIFF
--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -62,4 +62,4 @@ choices="$($fzf_command \
 )"
 choices=("${(@f)choices}")
 
-rm $tmp_dir/{compcap,groups}.$$ 2>/dev/null
+command rm $tmp_dir/{compcap,groups}.$$ 2>/dev/null

--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -54,5 +54,5 @@ echo -E "cd '$PWD'; fzf ${(qq)fzf_opts[@]} < $tmp_dir/list-$$ > $tmp_dir/result-
        -KE -R "source $tmp_dir/fzf-$$"
   < $tmp_dir/result-$$
 } always {
-  rm $tmp_dir/*-$$
+  command rm $tmp_dir/*-$$
 }


### PR DESCRIPTION
Many users have rm aliased to a different command or added flags such as `-I` or `-v`. Since these rm evocations aren't supposed to be verbose/visible, I'd find it best to force the use of the silent regular rm.