### PR TITLE
fix: FZF_TAB_HOME when a symlink is sourced or the path contains a space

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -293,7 +293,7 @@ zmodload -F zsh/stat b:zstat
 
 0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
 0="${${(M)0:#/*}:-$PWD/$0}"
-FZF_TAB_HOME=${0:A:h}
+FZF_TAB_HOME="${0:A:h}"
 
 source "$FZF_TAB_HOME"/lib/zsh-ls-colors/ls-colors.zsh fzf-tab-lscolors
 

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -293,9 +293,9 @@ zmodload -F zsh/stat b:zstat
 
 0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
 0="${${(M)0:#/*}:-$PWD/$0}"
-FZF_TAB_HOME=${0:h}
+FZF_TAB_HOME=${0:A:h}
 
-source ${0:h}/lib/zsh-ls-colors/ls-colors.zsh fzf-tab-lscolors
+source "$FZF_TAB_HOME"/lib/zsh-ls-colors/ls-colors.zsh fzf-tab-lscolors
 
 typeset -ga _ftb_group_colors=(
   $'\x1b[94m' $'\x1b[32m' $'\x1b[33m' $'\x1b[35m' $'\x1b[31m' $'\x1b[38;5;27m' $'\x1b[36m'


### PR DESCRIPTION
`FZF_TAB_HOME` will contain a wrong directory when instead of `fzf-tab.zsh` or `fzf-tab.plugin.zsh`, a symlink pointing to one of the two is sourced and the symlink lays in a different directory. In this case it will not contain the repository root but the directory in which the symlink is.
Errors also occur when the path of the repository contains spaces.

This fixes both of these issues by passing the path through `realpath` and quoting `$0`.