### PR TITLE
fix: Check also .bundle as a module extension

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -319,7 +319,7 @@ typeset -ga _ftb_group_colors=(
           "See https://github.com/Aloxaf/fzf-tab/pull/132 for more information%f%b"
   fi
 
-  if [[ -e $FZF_TAB_HOME/modules/Src/aloxaf/fzftab.so ]]; then
+  if [[ -e $FZF_TAB_HOME/modules/Src/aloxaf/fzftab.(so|bundle) ]]; then
     module_path+=("$FZF_TAB_HOME/modules/Src")
     zmodload aloxaf/fzftab
 


### PR DESCRIPTION
This PR adds checking `.bundle` as a module extension (for macOS) in the initialization code.
I forgot to add this check in the previous PR https://github.com/Aloxaf/fzf-tab/pull/121#issue-481954020 about module build in macOS.