### PR TITLE
refactor: Add explicit non-zero length string tests

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -45,15 +45,15 @@
   local key expanded __tmp_value=$'<\0>' # placeholder
   for key in $keys; do
     expanded=${(P)key}
-    if [[ $expanded ]]; then
+    if [[ -n $expanded ]]; then
       __tmp_value+=$'\0'$key$'\0'$expanded
     fi
   done
-  if [[ $expl ]]; then
+  if [[ -n $expl ]]; then
     # store group index
     __tmp_value+=$'\0group\0'$_ftb_groups[(ie)$expl]
   fi
-  if [[ $isfile ]]; then
+  if [[ -n $isfile ]]; then
     # NOTE: need a extra ${} here or ~ expansion won't work
     __tmp_value+=$'\0realdir\0'${${(Qe)~${:-$IPREFIX$hpre}}}
   fi
@@ -146,11 +146,11 @@
       ;;
   esac
 
-  if [[ $choices[1] && $choices[1] == $continuous_trigger ]]; then
+  if [[ -n $choices[1] && $choices[1] == $continuous_trigger ]]; then
     typeset -gi _ftb_continue=1
   fi
 
-  if [[ $choices[1] && $choices[1] == $accept_line ]]; then
+  if [[ -n $choices[1] && $choices[1] == $accept_line ]]; then
     typeset -gi _ftb_accept=1
   fi
   choices[1]=()

--- a/lib/-ftb-colorize
+++ b/lib/-ftb-colorize
@@ -14,7 +14,7 @@ fzf-tab-lscolors::from-mode "$1" "$lstat[3]" $stat[3]
 [[ -z $REPLY ]] && fzf-tab-lscolors::from-name $1
 
 # If this is a symlink
-if [[ $lstat[14] ]]; then
+if [[ -n $lstat[14] ]]; then
   local sym_color=$REPLY
   local rsv_color=$REPLY
   local rsv=$lstat[14]


### PR DESCRIPTION
 - Replace implicit `[[ $test ]]` with `[[ -n $test ]]`
 - Doesn't fix the issue reported in #184, but it does at least make the issues more obvious
     - ie. it would've saved me the time in changing all the logical conditions
 - It's also recommended in the [zsh documentation](http://zsh.sourceforge.net/Doc/Release/Conditional-Expressions.html) to use the more explicit version
     - > In other words, [[ $var ]] is the same as [[ -n $var ]]. It is recommended that the second, explicit, form be used where possible.


