### PR TITLE
Fix a bug about globdots

### DIFF
--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -45,7 +45,7 @@ print -r -- ${ftb_preview_init/{f}/\$1} > $tmp_dir/ftb_preview_init.$$
 binds=${binds//{_FTB_INIT_}/. $tmp_dir/ftb_preview_init.$$ {f} $'\n'}
 
 local -i header_lines=$#_ftb_headers
-local -i lines=$(( $#_ftb_compcap + 2 + header_lines ))
+local -i lines=$(( $#_ftb_compcap + 4 + header_lines ))
 local reload_command="$commands[zsh] $FZF_TAB_HOME/lib/ftb-switch-group $$ $header_lines $tmp_dir"
 
 # detect if we will use tmux popup

--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -45,7 +45,11 @@ print -r -- ${ftb_preview_init/{f}/\$1} > $tmp_dir/ftb_preview_init.$$
 binds=${binds//{_FTB_INIT_}/. $tmp_dir/ftb_preview_init.$$ {f} $'\n'}
 
 local -i header_lines=$#_ftb_headers
-local -i lines=$(( $#_ftb_compcap + 4 + header_lines ))
+if [[ $(zstyle -L ':completion:*' special-dirs) =~ "true" ]]; then
+	local -i lines=$(( $#_ftb_compcap + 4 + header_lines ))
+else
+	local -i lines=$(( $#_ftb_compcap + 2 + header_lines ))
+fi
 local reload_command="$commands[zsh] $FZF_TAB_HOME/lib/ftb-switch-group $$ $header_lines $tmp_dir"
 
 # detect if we will use tmux popup

--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -45,7 +45,7 @@ print -r -- ${ftb_preview_init/{f}/\$1} > $tmp_dir/ftb_preview_init.$$
 binds=${binds//{_FTB_INIT_}/. $tmp_dir/ftb_preview_init.$$ {f} $'\n'}
 
 local -i header_lines=$#_ftb_headers
-if [[ $(zstyle -L ':completion:*' special-dirs) =~ "true" ]]; then
+if [[ $(zstyle -L ':completion:*' special-dirs) =~ "true" && $FZF_DEFAULT_OPTS =~ "--border" ]]; then
 	local -i lines=$(( $#_ftb_compcap + 4 + header_lines ))
 else
 	local -i lines=$(( $#_ftb_compcap + 2 + header_lines ))


### PR DESCRIPTION
If "globdots" option is enabled, it shows all dotfiles. The problem was, if there's only one or two files in a folder, then fzf-tab only shows only two items and mostly current folder (.) and parent folder (..) consumes these two spaces. It seems showing at least 4 items is an appropriate solution. I actually tried to check whether "globdots" is enabled, like `[[ -o globdots ]]`, but it didn't work.