### PR TITLE
reload now runs zsh with -f

### DIFF
--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -46,7 +46,7 @@ binds=${binds//{_FTB_INIT_}/. $tmp_dir/ftb_preview_init.$$ {f} $'\n'}
 
 local -i header_lines=$#_ftb_headers
 local -i lines=$(( $#_ftb_compcap + 2 + header_lines ))
-local reload_command="$commands[zsh] $FZF_TAB_HOME/lib/ftb-switch-group $$ $header_lines $tmp_dir"
+local reload_command="$commands[zsh] -f $FZF_TAB_HOME/lib/ftb-switch-group $$ $header_lines $tmp_dir"
 
 # detect if we will use tmux popup
 local use_tmux_popup=0


### PR DESCRIPTION
I have changed the reload comand's `zsh` to `$(which zsh) -f`, as I have a lot of config in my zsh dotfiles which take seconds to load. `which zsh` is also better because `commands[zsh]` mistakenly returns a `zsh` directory in my path (I do have `setopt hash_executables_only`, but I think you do `emulate -L zsh` so it gets voided).