### PR TITLE
fix multiline prompt

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -213,13 +213,11 @@ fzf-tab-complete() {
     }
     if (( _ftb_continue )); then
       zle .split-undo
-      zle .reset-prompt
       zle -R
       zle fzf-tab-dummy
     fi
   done
   echoti cnorm >/dev/tty 2>/dev/null
-  zle .redisplay
   (( _ftb_accept )) && zle .accept-line
   return $ret
 }


### PR DESCRIPTION
Hi,

I don't know what I'm doing, but I know it fixes my problem.
I'm using oh-my-zsh with p10k and a multi-line prompt. The multi-line seems to break fzf-tab,with my prompt scrolling up everytime I press tab and there no completion, and everytime I press '/' for continuous completion.

I have no idea whether this PR would break other users but I'll keep using it in my fork since I need it. So better open a PR and share it