### PR TITLE
Add ability to override fzf keybindings with FZF_TAB_KEYBINDS

### DIFF
--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -23,7 +23,7 @@ if (( \$+ctxt[realdir] )); then
   export realpath=\${ctxt[realdir]}\$word
 fi
 "
-local binds=tab:down,btab:up,change:top,ctrl-space:toggle
+local binds="${FZF_TAB_KEYBINDS:-tab:down,btab:up,change:top,ctrl-space:toggle}"
 local fzf_command fzf_flags fzf_preview debug_command tmp switch_group fzf_pad
 local ret=0
 


### PR DESCRIPTION
Adding an env variable allows configuration of keybindings specific to `fzf-tab` without having to override or change `fzf` functionality elsewhere.