### PR TITLE
fix: position of tmux popup when status-position is 'top'

### DIFF
--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -29,7 +29,7 @@ local -a tmp=($(command tmux display-message -p "#{pane_top} #{cursor_y} #{pane_
 local cursor_y=$((tmp[1] + tmp[2])) cursor_x=$((tmp[3] + tmp[4])) window_height=$tmp[5] window_width=$tmp[6]
 
 if [ "$tmp[8]" = 'top' ]; then
-  cursor_y=$((cursor_y + tmp[7] - 1))
+  cursor_y=$((cursor_y + tmp[7]))
 fi
 
 # if not called by fzf-tab

--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -26,10 +26,11 @@ fzf_opts=(${${fzf_opts/--height*}/--layout*})
 
 # get position of cursor and size of window
 local -a tmp=($(command tmux display-message -p "#{pane_top} #{cursor_y} #{pane_left} #{cursor_x} #{window_height} #{window_width} #{status} #{status-position}"))
-local cursor_y=$((tmp[1] + tmp[2])) cursor_x=$((tmp[3] + tmp[4])) window_height=$tmp[5] window_width=$tmp[6]
+local cursor_y=$((tmp[1] + tmp[2])) cursor_x=$((tmp[3] + tmp[4])) window_height=$tmp[5] window_width=$tmp[6] window_top=0
 
 if [ "$tmp[8]" = 'top' ]; then
-  cursor_y=$((cursor_y + tmp[7]))
+  window_top=$tmp[7]
+  cursor_y=$((cursor_y + window_top))
 fi
 
 # if not called by fzf-tab
@@ -61,11 +62,11 @@ local popup_height popup_y popup_width popup_x
 # calculate the popup height and y position
 if (( cursor_y * 2 > window_height )); then
   # show above the cursor
-  popup_height=$(( min(comp_lines + 4, cursor_y) ))
+  popup_height=$(( min(comp_lines + 4, cursor_y - window_top) ))
   popup_y=$cursor_y
 else
   # show below the cursor
-  popup_height=$(( min(comp_lines + 4, window_height - cursor_y) ))
+  popup_height=$(( min(comp_lines + 4, window_height - cursor_y + window_top - 1) ))
   popup_y=$(( cursor_y + popup_height + 1 ))
   fzf_opts+=(--layout=reverse)
 fi

--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -29,7 +29,7 @@ local -a tmp=($(command tmux display-message -p "#{pane_top} #{cursor_y} #{pane_
 local cursor_y=$((tmp[1] + tmp[2])) cursor_x=$((tmp[3] + tmp[4])) window_height=$tmp[5] window_width=$tmp[6]
 
 if [ "$tmp[8]" = 'top' ]; then
-  cursor_y=$((cursor_y + tmp[7]))
+  cursor_y=$((cursor_y + tmp[7] - 1))
 fi
 
 # if not called by fzf-tab

--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -25,8 +25,12 @@ local -a fzf_opts=($@)
 fzf_opts=(${${fzf_opts/--height*}/--layout*})
 
 # get position of cursor and size of window
-local -a tmp=($(command tmux display-message -p "#{pane_top} #{cursor_y} #{pane_left} #{cursor_x} #{window_height} #{window_width}"))
+local -a tmp=($(command tmux display-message -p "#{pane_top} #{cursor_y} #{pane_left} #{cursor_x} #{window_height} #{window_width} #{status} #{status-position}"))
 local cursor_y=$((tmp[1] + tmp[2])) cursor_x=$((tmp[3] + tmp[4])) window_height=$tmp[5] window_width=$tmp[6]
+
+if [ "$tmp[8]" = 'top' ]; then
+  cursor_y=$((cursor_y + tmp[7]))
+fi
 
 # if not called by fzf-tab
 if (( ! $+IN_FZF_TAB )); then

--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -28,7 +28,7 @@ fzf_opts=(${${fzf_opts/--height*}/--layout*})
 local -a tmp=($(command tmux display-message -p "#{pane_top} #{cursor_y} #{pane_left} #{cursor_x} #{window_height} #{window_width} #{status} #{status-position}"))
 local cursor_y=$((tmp[1] + tmp[2])) cursor_x=$((tmp[3] + tmp[4])) window_height=$tmp[5] window_width=$tmp[6] window_top=0
 
-if [ "$tmp[8]" = 'top' ]; then
+if [[ $tmp[8] == 'top' ]]; then
   window_top=$tmp[7]
   cursor_y=$((cursor_y + window_top))
 fi


### PR DESCRIPTION
This fixes the tmux popup position when the status line is configured to be at the top of the window. It also correctly supports multi-line status.

To test this, here's an example of tmux.conf with 2 lines for the status at the top of the window:
```
set -g status 2
set -g status-position top
```
