### PR TITLE
lib/ftb-tmux-popup: remove awk invocation from comp_length declaration

### DIFF
--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -53,7 +53,7 @@ if (( comp_lines <= 500 )); then
   done
 else
   # FIXME: can't get the correct width of CJK characters.
-  comp_length=$(command perl -pe 's/\x1b\[[0-9;]*m//g;s/\x00//g' $tmp_dir/completions.$$ | command awk 'length > max_length { max_length = length; } END { print max_length }')
+  comp_length=$( command perl -ne 's/\x1b\[[0-9;]*m//g;s/\x00//g; $m= length() if $m < length(); END { print $m }' < $tmp_dir/completions.$$ )
 fi
 comp_length=$(( comp_length + $popup_pad[1] ))
 


### PR DESCRIPTION
Might as well use Perl to calculate the max length too - it might be a micro-optimisation but it's one less `exec()` on every invocation of `ftb-tmux-popup`.