### PR TITLE
-ftb-fzf: Expand fzf-flags correctly

### DIFF
--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -91,7 +91,7 @@ $fzf_command \
   --query=$_ftb_query \
   --tiebreak=begin \
   ${fzf_preview:+--preview=$ftb_preview_init$fzf_preview} \
-  $fzf_flags < $tmp_dir/completions.$$ || ret=$?
+  ${=fzf_flags} < $tmp_dir/completions.$$ || ret=$?
 
 if (( ! use_tmux_popup )); then
   echoti civis >/dev/tty 2>/dev/null


### PR DESCRIPTION
Word splits `fzf-flags` so that multiple flags can be given 