### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Replace zsh's default completion selection menu with fzf!
 - [Install](#install)
     - [Manual](#manual)
     - [Antigen](#antigen)
+    - [Fig](#fig)
     - [Zinit](#zinit)
     - [Oh-My-Zsh](#oh-my-zsh)
     - [Prezto](#prezto)
@@ -49,6 +50,14 @@ source ~/somewhere/fzf-tab.plugin.zsh
 ```zsh
 antigen bundle Aloxaf/fzf-tab
 ```
+
+### Fig
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `fzf-tab` in just one click.
+
+<a href="https://fig.io/plugins/other/fzf-tab" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
 
 ### Zinit
 


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

`fzf-tab` is already listed in the store so we'd love to have it listed as a download method on your readme.

Thanks so much and please let me know if you have any questions!
