### PR TITLE
docs: added warning to install fzf

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Replace zsh's default completion selection menu with fzf!
 # Install
 
 **NOTE: fzf-tab needs to be loaded after `compinit`, but before plugins which will wrap widgets, such as [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) or [fast-syntax-highlighting](https://github.com/zdharma-continuum/fast-syntax-highlighting)!!**
+**NOTE 2: fzf-tab ALSO needs [fzf-tab](https://github.com/junegunn/fzf) installed, otherwise it cannot work!**
 
 ### Manual
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Replace zsh's default completion selection menu with fzf!
 # Install
 
 **NOTE: fzf-tab needs to be loaded after `compinit`, but before plugins which will wrap widgets, such as [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) or [fast-syntax-highlighting](https://github.com/zdharma-continuum/fast-syntax-highlighting)!!**
-**NOTE 2: fzf-tab ALSO needs [fzf-tab](https://github.com/junegunn/fzf) installed, otherwise it cannot work!**
+**NOTE 2: fzf-tab ALSO needs [fzf](https://github.com/junegunn/fzf) installed, otherwise it cannot work!**
 
 ### Manual
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Replace zsh's default completion selection menu with fzf!
 # Install
 
 **NOTE: fzf-tab needs to be loaded after `compinit`, but before plugins which will wrap widgets, such as [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) or [fast-syntax-highlighting](https://github.com/zdharma-continuum/fast-syntax-highlighting)!!**
+
 **NOTE 2: fzf-tab ALSO needs [fzf](https://github.com/junegunn/fzf) installed, otherwise it cannot work!**
 
 ### Manual


### PR DESCRIPTION
Apparently this was obvious to the developers of this package and to the thousands of people before me that installed this, but since I am an idiot I didn't realize that fzf MUST be installed in the system for fzf-tab to work.

Added a warning for the other idiots like me out there.