### PR TITLE
feat: toggle fzf-tab for a specific command

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -14,8 +14,14 @@
              i: S: s: I: x: r: R: W: F: M+: E: q e Q n U C \
              J:=__ V:=__ a=__ l=__ k=__ o=__ 1=__ 2=__
 
+  # store $curcontext for further usage
+  _ftb_curcontext=${curcontext#:}
+
   # just delegate and leave if any of -O, -A or -D are given or fzf-tab is not enabled
-  if (( $#_oad != 0 || ! IN_FZF_TAB )); then
+  # or fzf-tab is disabled in the current context
+  if (( $#_oad != 0 || ! IN_FZF_TAB )) \
+    || { -ftb-zstyle -m disabled-on "any" } \
+    || ({ -ftb-zstyle -m disabled-on "files" } && [[ -n $isfile ]]); then
     builtin compadd "$@"
     return
   fi
@@ -30,9 +36,6 @@
   if (( $#__hits == 0 )); then
     return $ret
   fi
-
-  # store $curcontext for furthur usage
-  _ftb_curcontext=${curcontext#:}
 
   # only store the fist `-X`
   expl=$expl[2]


### PR DESCRIPTION
Fixes https://github.com/Aloxaf/fzf-tab/issues/221. This pull request introduces a new configuration flag `disabled-on`. It accepts the following values : 

| Value | Description |
|:---:|:--- |
| `any` | Disable fzf-tab for all matches. Fallback to the default completion selection menu. |
| `files` | Only disable fzf-tab if all of the matches are names of files. See flag `-f` in <https://zsh.sourceforge.io/Doc/Release/Completion-Widgets.html#Completion-Builtin-Commands>. |
| `none` | Enable fzf-tab for all matches. |

---

Configuration example for the use-case of https://github.com/Coqueiro

```zsh
# Enable fzf-tab everywhere except on the cd command
zstyle ':fzf-tab:complete:cd:*' disabled-on any
```

Alternative configuration for the use-case of https://github.com/Coqueiro

```zsh
# Enable fzf-tab only to complete non-files, and files are displayed using the regular horizontal grid
zstyle ':fzf-tab:*' disabled-on files
```

Configuration example for the use-case of https://github.com/wookayin

```zsh
# Enable fzf-tab only on specific commands
zstyle ':fzf-tab:*' disabled-on any
zstyle ':fzf-tab:complete:<command in allowlist>:*' disabled-on none
```