### PR TITLE
feat: add words array to environment

### DIFF
--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -22,7 +22,7 @@ export word=\${(Q)ctxt[word]}
 if (( \$+ctxt[realdir] )); then
   export realpath=\${ctxt[realdir]}\$word
 fi
-export words='${words}'
+$(typeset -p words)
 "
 local binds=tab:down,btab:up,change:top,ctrl-space:toggle
 local fzf_command fzf_flags fzf_preview debug_command tmp switch_group fzf_pad

--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -8,7 +8,7 @@ zmodload zsh/mapfile
 local -a _ftb_compcap=(\"\${(@f)mapfile[$tmp_dir/compcap.$$]}\")
 local -a _ftb_groups=(\"\${(@f)mapfile[$tmp_dir/groups.$$]}\")
 local bs=\$'\2'
-# get descriptoin
+# get description
 export desc=\${\${\"\$(<'{f}')\"%\$'\0'*}#*\$'\0'}
 # get ctxt for current completion
 local -A ctxt=(\"\${(@0)\${_ftb_compcap[(r)\${(b)desc}\$bs*]#*\$bs}}\")

--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -22,9 +22,7 @@ export word=\${(Q)ctxt[word]}
 if (( \$+ctxt[realdir] )); then
   export realpath=\${ctxt[realdir]}\$word
 fi
-if (( $+commands[${words[1]}] )); then
-  export command="${words[1]}"
-fi
+export words='${words}'
 "
 local binds=tab:down,btab:up,change:top,ctrl-space:toggle
 local fzf_command fzf_flags fzf_preview debug_command tmp switch_group fzf_pad

--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -22,6 +22,9 @@ export word=\${(Q)ctxt[word]}
 if (( \$+ctxt[realdir] )); then
   export realpath=\${ctxt[realdir]}\$word
 fi
+if (( $+commands[${words[1]}] )); then
+  export command="${words[1]}"
+fi
 "
 local binds=tab:down,btab:up,change:top,ctrl-space:toggle
 local fzf_command fzf_flags fzf_preview debug_command tmp switch_group fzf_pad


### PR DESCRIPTION
Add the current command to the environment to be able to e.g. display the man page in preview:

```
# Preview man page when completing options
zstyle ':fzf-tab:complete:*:options' fzf-preview 'if [[ -n "${command}" ]]; then man ${command} | bat --color=always --language=man --style=numbers ; fi'
```