### PR TITLE
Module build summary

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -340,6 +340,11 @@ build-fzf-tab-module() {
   pushd $FZF_TAB_HOME/modules
   CPPFLAGS=-I/usr/local/include CFLAGS="-g -Wall -O2" LDFLAGS=-L/usr/local/lib ./configure --disable-gdbm --without-tcsetpgrp ${MACOS:+DL_EXT=bundle}
   make -j$(nproc)
+  if [[ $? -ne 0 ]]; then
+	  echo "The module building has failed. See the output above for details." >&2
+  else
+	  echo "The module has been built sucessfully."
+  fi
   popd
 }
 


### PR DESCRIPTION
# Abstract

This PR reports a module build summary.

## Pitch

The output of `make` is quite long, and while helpful, it is nice to have an extra one-line summary of the build status. It can save users a lot of time analyzing the logs just to confirm that the module was successfully built and installed.

## Reference
From the `make` manual:
> GNU make exits with a status of zero if all makefiles were successfully parsed and no targets that were built failed.