### PR TITLE
feat: add tags `fzf-min-height`, `popup-min-size`

### DIFF
--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -1,5 +1,9 @@
 #!/hint/zsh
 
+# import math functions
+autoload -Uz zmathfunc
+zmathfunc
+
 local tmp_dir=${TMPPREFIX:-/tmp/zsh}-fzf-tab-$USER
 [[ -d $tmp_dir ]] || command mkdir $tmp_dir
 
@@ -25,7 +29,7 @@ fi
 $(typeset -p words)
 "
 local binds=tab:down,btab:up,change:top,ctrl-space:toggle
-local fzf_command fzf_flags fzf_preview debug_command tmp switch_group fzf_pad
+local fzf_command fzf_flags fzf_preview debug_command tmp switch_group fzf_pad fzf_min_height
 local ret=0
 
 -ftb-zstyle -s fzf-command fzf_command || fzf_command=fzf
@@ -34,6 +38,7 @@ local ret=0
 -ftb-zstyle -s fzf-preview fzf_preview
 -ftb-zstyle -a switch-group switch_group || switch_group=(F1 F2)
 -ftb-zstyle -s fzf-pad fzf_pad || fzf_pad=2
+-ftb-zstyle -s fzf-min-height fzf_min_height || fzf_min_height=0
 
 -ftb-zstyle -a debug-command debug_command && {
   ${(eX)debug_command} $fzf_flags
@@ -84,7 +89,7 @@ $fzf_command \
   --delimiter='\x00' \
   --expect=$continuous_trigger,$print_query,$accept_line \
   --header-lines=$header_lines \
-  --height=${FZF_TMUX_HEIGHT:=$(( lines > LINES / 3 * 2 ? LINES / 3 * 2 : lines ))} \
+  --height=${FZF_TMUX_HEIGHT:=$(( min(max(lines, fzf_min_height), LINES / 3 * 2)  ))} \
   --layout=reverse \
   --multi \
   --nth=2,3 \

--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -39,9 +39,11 @@ if (( ! $+IN_FZF_TAB )); then
   cat > $tmp_dir/completions.$$
 fi
 
-local text REPLY comp_lines comp_length length popup_pad
+local text REPLY comp_lines comp_length length popup_pad popup_min_size
 
 zstyle -a ":fzf-tab:$_ftb_curcontext" popup-pad popup_pad || popup_pad=(0 0)
+zstyle -a ":fzf-tab:$_ftb_curcontext" popup-min-size popup_min_size || popup_min_size=(0 0)
+echo $popup_min_size > /tmp/aaf
 
 # get the size of content, note we should remove all ANSI color code
 comp_lines=$(( ${#${(f)mapfile[$tmp_dir/completions.$$]}} + $popup_pad[2] ))
@@ -67,17 +69,17 @@ fi
 # calculate the popup height and y position
 if (( cursor_y * 2 > window_height )); then
   # show above the cursor
-  popup_height=$(( min(comp_lines + 4, cursor_y - window_top) + adjust_height ))
+  popup_height=$(( min(max(comp_lines + 4, popup_min_size[2]), cursor_y - window_top) + adjust_height ))
   popup_y=$cursor_y
 else
   # show below the cursor
-  popup_height=$(( min(comp_lines + 4, window_height - cursor_y + window_top - 1) + adjust_height ))
+  popup_height=$(( min(max(comp_lines + 4, popup_min_size[2]), window_height - cursor_y + window_top - 1) + adjust_height ))
   popup_y=$(( cursor_y + popup_height + 1 ))
   fzf_opts+=(--layout=reverse)
 fi
 
 # calculate the popup width and x position
-popup_width=$(( min(comp_length + 5, window_width) ))
+popup_width=$(( min(max(comp_length + 5, popup_min_size[1]), window_width) ))
 popup_x=$(( cursor_x + popup_width > window_width ? window_width - popup_width : cursor_x ))
 
 echo -E "$commands[fzf] ${(qq)fzf_opts[@]} < $tmp_dir/completions.$$ > $tmp_dir/result-$$" > $tmp_dir/fzf-$$

--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -43,7 +43,6 @@ local text REPLY comp_lines comp_length length popup_pad popup_min_size
 
 zstyle -a ":fzf-tab:$_ftb_curcontext" popup-pad popup_pad || popup_pad=(0 0)
 zstyle -a ":fzf-tab:$_ftb_curcontext" popup-min-size popup_min_size || popup_min_size=(0 0)
-echo $popup_min_size > /tmp/aaf
 
 # get the size of content, note we should remove all ANSI color code
 comp_lines=$(( ${#${(f)mapfile[$tmp_dir/completions.$$]}} + $popup_pad[2] ))


### PR DESCRIPTION
#

Add two new tags `fzf-min-height`, `popup-min-size`

| Tag            | Type   | Description                                |
| -------------- | ------ | ------------------------------------------ |
| fzf-min-height | int    | minimal height of fzf-tab widget           |
| popup-min-size | int[2] | minimal width and height of fzf-tmux-popup |

## use cases

Setting a minimal size of fzf-tmux-popup window can prevent content from being
truncated by fzf preview window.

**default**
![image](https://user-images.githubusercontent.com/52642831/196944524-8369545b-ae82-4bcc-999d-eb15e15169c3.png)


**zstyle ':fzf-tab:*' popup-min-size 60 8**
![image](https://user-images.githubusercontent.com/52642831/196944434-712e1a85-f870-4f36-9369-ca3651f5d6d1.png)

