### PR TITLE
fix: Only add to `$FPATH` once

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -379,7 +379,9 @@ typeset -ga _ftb_group_colors=(
 () {
   emulate -L zsh -o extended_glob
 
-  fpath+=($FZF_TAB_HOME/lib)
+  if [[ ! "$FPATH" == *${FZF_TAB_HOME}/lib* ]]; then
+    fpath+=($FZF_TAB_HOME/lib)
+  fi
 
   autoload -Uz is-at-least -- $FZF_TAB_HOME/lib/-#ftb*(:t)
 

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -379,7 +379,7 @@ typeset -ga _ftb_group_colors=(
 () {
   emulate -L zsh -o extended_glob
 
-  if [[ ! "$FPATH" == *${FZF_TAB_HOME}/lib* ]]; then
+  if (( ! $fpath[(I)$FZF_TAB_HOME/lib] )); then
     fpath+=($FZF_TAB_HOME/lib)
   fi
 


### PR DESCRIPTION
# What
Rather than adding to `$FPATH` every time a new shell is created, check to see if it's already present. This means we don't end up with multiple instances of `${FZF_TAB_HOME}/lib` included in `$FPATH`.

# Example
## Before
```
$ echo $FPATH | tr ":" "\n"
[...]
${HOME}/fzf-tab/lib
$ zsh   # open a subshell
$ echo $FPATH | tr ":" "\n"
[...]
${HOME}/fzf-tab/lib
${HOME}/fzf-tab/lib
```

## After
```
$ echo $FPATH | tr ":" "\n"
[...]
${HOME}/fzf-tab/lib
$ zsh   # open a subshell
$ echo $FPATH | tr ":" "\n"
[...]
${HOME}/fzf-tab/lib
```