### PR TITLE
fix: Adds -std=c99 compiler flag in build-fzf-tab-module()

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -348,7 +348,7 @@ build-fzf-tab-module() {
     NPROC=$(nproc)
   fi
   pushd $FZF_TAB_HOME/modules
-  CPPFLAGS=-I/usr/local/include CFLAGS="-g -Wall -O2" LDFLAGS=-L/usr/local/lib ./configure --disable-gdbm --without-tcsetpgrp ${use_bundle:+DL_EXT=bundle}
+  CPPFLAGS=-I/usr/local/include CFLAGS="-g -Wall -O2 -std=c99" LDFLAGS=-L/usr/local/lib ./configure --disable-gdbm --without-tcsetpgrp ${use_bundle:+DL_EXT=bundle}
   make -j${NPROC}
   local ret=$?
   popd


### PR DESCRIPTION
Adds -std=c99 compiler flag in build-fzf-tab-module() to fix the following error.

fzftab.c: In function ‘compile_patterns’:
fzftab.c:77:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
fzftab.c:77:5: note: use option -std=c99 or -std=gnu99 to compile your code
fzftab.c:93:14: error: redefinition of ‘i’
fzftab.c:77:14: note: previous definition of ‘i’ was here
fzftab.c:93:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
fzftab.c:104:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
fzftab.c: In function ‘colorize_from_name’:
fzftab.c:171:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
fzftab.c: In function ‘bin_fzf_tab_compcap_generate’:
fzftab.c:274:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
fzftab.c: In function ‘ftb_strcat’:
fzftab.c:308:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
fzftab.c: In function ‘fzf_tab_colorize’:
fzftab.c:380:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
fzftab.c: In function ‘bin_fzf_tab_candidates_generate’:
fzftab.c:416:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
fzftab.c:426:9: error: ‘for’ loop initial declarations are only allowed in C99 mode