### PR TITLE
tmux-popup: conditionally import math functions

### DIFF
--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -7,9 +7,11 @@
 #   ls | ftb-tmux-popup
 emulate -L zsh -o extended_glob
 
-# import min
-autoload -Uz zmathfunc
-zmathfunc
+# import math functions (only if they're not already defined)
+if [[ -z "$functions[zsh_math_func_min]" ]]; then
+  autoload -Uz zmathfunc
+  zmathfunc
+fi
 
 : ${tmp_dir:=${TMPPREFIX:-/tmp/zsh}-fzf-tab-$USER}
 

--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -8,7 +8,7 @@
 emulate -L zsh -o extended_glob
 
 # import math functions (only if they're not already defined)
-if [[ -z "$functions[zsh_math_func_min]" ]]; then
+if (( ! $+functions[zsh_math_func_min] )); then
   autoload -Uz zmathfunc
   zmathfunc
 fi


### PR DESCRIPTION
Without this, I'm seeing "min / max / sum" already defined errors on
RHEL 8, the previous definition presumably from -ftb-fzf.

This seems independent of the Zsh version and I'm not really sure what
changed between RHEL 7 and RHEL 8 that triggers this.