### PR TITLE
feat: prefix completion

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -234,12 +234,12 @@ fzf-tab-debug() {
 
 fzf-tab-complete() {
   # this name must be ugly to avoid clashes
-  local -a _ftb_choices _ftb_compcap
-  local -i _ftb_continue=1 _ftb_continue_last=0 _ftb_accept=0 ret=0 _ftb_finish=0
+  local -i _ftb_continue=1 _ftb_continue_last=0 _ftb_accept=0 ret=0
   # hide the cursor until finishing completion, so that users won't see cursor up and down
   # NOTE: MacOS Terminal doesn't support civis & cnorm
   echoti civis >/dev/tty 2>/dev/null
   while (( _ftb_continue )); do
+    local _ftb_choices=() _ftb_compcap=() _ftb_finish=0
     _ftb_continue=0
     local IN_FZF_TAB=1
     {

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -132,7 +132,7 @@ builtin unalias -m '[^+]*'
       ;;
     *)
 
-      if -ftb-zstyle -T insert-unambiguous insert_unambiguous && [[ "$compstate[unambiguous]" != "$PREFIX" ]]; then
+      if [[ $compstate[insert] == *"unambiguous" ]] && [[ "$compstate[unambiguous]" != "$PREFIX" ]]; then
         compstate[list]=
         compstate[insert]=unambiguous
         return 0

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -159,7 +159,7 @@ builtin unalias -m '[^+]*'
         compstate[list]=
         compstate[insert]=
         if (( $#choices[1] > 0 )); then
-            compstate[insert]='2'
+            compstate[insert]='1'
             [[ $RBUFFER == ' '* ]] || compstate[insert]+=' '
         fi
         return $ret

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -88,7 +88,7 @@ builtin unalias -m '[^+]*'
   fi
 
   # tell zsh that the match is successful
-  builtin compadd -U -qS '' -R -ftb-remove-space ''
+  builtin compadd "$@"
 }
 
 # when insert multi results, a whitespace will be added to each result
@@ -131,6 +131,13 @@ builtin unalias -m '[^+]*'
       fi
       ;;
     *)
+
+      if [[ "$compstate[unambiguous]" != "$PREFIX" ]]; then
+        compstate[list]=
+        compstate[insert]=unambiguous
+        return 0
+      fi
+
       -ftb-generate-query      # sets `_ftb_query`
       -ftb-generate-header     # sets `_ftb_headers`
       -ftb-zstyle -s print-query print_query || print_query=alt-enter

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -131,7 +131,9 @@ builtin unalias -m '[^+]*'
       ;;
     *)
 
-      if [[ $compstate[insert] == *"unambiguous" ]] && [[ "$compstate[unambiguous]" != "$PREFIX" ]]; then
+      if (( ! _ftb_continue_last )) \
+        && [[ $compstate[insert] == *"unambiguous" ]] \
+        && [[ "$compstate[unambiguous]" != "$PREFIX" ]]; then
         compstate[list]=
         compstate[insert]=unambiguous
         _ftb_finish=1

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -132,7 +132,7 @@ builtin unalias -m '[^+]*'
       ;;
     *)
 
-      if [[ "$compstate[unambiguous]" != "$PREFIX" ]]; then
+      if -ftb-zstyle -T insert-unambiguous insert_unambiguous && [[ "$compstate[unambiguous]" != "$PREFIX" ]]; then
         compstate[list]=
         compstate[insert]=unambiguous
         return 0
@@ -193,7 +193,7 @@ builtin unalias -m '[^+]*'
   compstate[list]=
   compstate[insert]=
   if (( $#choices == 1 )); then
-    compstate[insert]='2'
+    compstate[insert]='1'
     [[ $RBUFFER == ' '* ]] || compstate[insert]+=' '
   elif (( $#choices > 1 )); then
     compstate[insert]='all'

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -91,13 +91,6 @@ builtin unalias -m '[^+]*'
   builtin compadd "$@"
 }
 
-# when insert multi results, a whitespace will be added to each result
-# remove left space of our fake result because I can't remove right space
-# FIXME: what if the left char is not whitespace: `echo $widgets[\t`
--ftb-remove-space() {
-  [[ $LBUFFER[-1] == ' ' ]] && LBUFFER[-1]=''
-}
-
 -ftb-zstyle() {
   zstyle $1 ":fzf-tab:$_ftb_curcontext" ${@:2}
 }
@@ -193,7 +186,7 @@ builtin unalias -m '[^+]*'
   return $ret
 }
 
--ftb-complete-apply() {
+_fzf-tab-apply() {
   local choice bs=$'\2'
   for choice in "$_ftb_choices[@]"; do
     local -A v=("${(@0)${_ftb_compcap[(r)${(b)choice}$bs*]#*$bs}}")
@@ -245,7 +238,7 @@ fzf-tab-complete() {
     {
       zle .fzf-tab-orig-$_ftb_orig_widget || ret=$?
       if (( ! ret && ! _ftb_finish )); then
-        zle -- -ftb-complete-apply || ret=$?
+        zle _fzf-tab-apply || ret=$?
       fi
     } always {
       IN_FZF_TAB=0
@@ -272,7 +265,7 @@ zle -N fzf-tab-complete
 zle -N fzf-tab-dummy
 # this is registered as a completion widget
 # so that we can have a clean completion list to only insert the results user selected
-zle -C -- -ftb-complete-apply complete-word -ftb-complete-apply
+zle -C _fzf-tab-apply complete-word _fzf-tab-apply
 
 disable-fzf-tab() {
   emulate -L zsh -o extended_glob

--- a/test/fzftab.ztst
+++ b/test/fzftab.ztst
@@ -61,6 +61,11 @@
 >C1:{file2}
 
   comptest $': d\t'
+0:unambiguous prefix
+>line: {: dir}{}
+
+  comptesteval 'zstyle ":completion:*" menu true'
+  comptest $': d\t'
 0:prefix
 >line: {: dir1/}{}
 >QUERY:{dir}

--- a/test/fzftab.ztst
+++ b/test/fzftab.ztst
@@ -123,6 +123,8 @@
 >line: {: asd}{}
 >WARN:{`file'}
 
+# enclose ' for syntax highlight
+
   comptesteval "touch 'abc def'"
   comptest $': ./a\t'
 0:filename with space
@@ -160,7 +162,6 @@
   comptest $'git add dir1\t'
 0:add empty word
 >line: {git add dir1/}{}
-# FIXME：why two warnings？
 
   comptesteval "zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|=*' 'l:|=* r:|=*'"
   comptesteval "touch vim.coc"

--- a/test/fzftab.ztst
+++ b/test/fzftab.ztst
@@ -113,8 +113,6 @@
 0:warnings
 >line: {: asd}{}
 >WARN:{`file'}
->WARN:{`file'}
-# FIXME：why two warnings？
 
   comptesteval "touch 'abc def'"
   comptest $': ./a\t'

--- a/test/fzftab.ztst
+++ b/test/fzftab.ztst
@@ -64,6 +64,15 @@
 0:unambiguous prefix
 >line: {: dir}{}
 
+  comptesteval '_tst() { compadd /home /usr /lib; compstate[insert]=menu }'
+  comptest $'tst \t'
+0:force list
+>line: {tst /home }{}
+>QUERY:{/}
+>C0:{/home}
+>C0:{/lib}
+>C0:{/usr}
+
   comptesteval 'zstyle ":completion:*" menu true'
   comptest $': d\t'
 0:prefix

--- a/test/select
+++ b/test/select
@@ -2,8 +2,12 @@
 
 zmodload zsh/zutil
 
-local -A headers range query
+local -A headers range query expect
 
+# -h: lines of headers
+# -n: selection index, if it is QUERY, query string will be used
+# -q: query string
+# -e: expect key
 zparseopts -E h:=headers n:=range q:=query e:=expect
 
 print -r -- "${query//\"/}"


### PR DESCRIPTION
This PR is another approch to let fzf-tab complete the common prefix.
It can handle some corner cases like https://github.com/Aloxaf/fzf-tab/pull/384#issuecomment-1957202220 and zsh-z.

**how to enable**

```zsh
# temporary
zstyle ':completion:*' menu no
```

**known bugs**

~~It breaks multiple selections~~

**related issues/pr**

#8 #384