### PR TITLE
Reset prompt after completion done

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -256,6 +256,7 @@ fzf-tab-complete() {
     fi
   done
   echoti cnorm >/dev/tty 2>/dev/null
+  zle reset-prompt
   zle .redisplay
   (( _ftb_accept )) && zle .accept-line
   return $ret


### PR DESCRIPTION
Somehow if I don't call `zle reset-prompt`, the highlighting turns off when the completion is done (either there's no more choice or when I ctrl-c)