### PR TITLE
fix: remove -E from zparseopts

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -14,7 +14,7 @@ builtin unalias -m '[^+]*'
   # parse all options
   local -A apre hpre dscrs _oad _mesg
   local -a isfile _opts __ expl
-  zparseopts -E -a _opts P:=apre p:=hpre d:=dscrs X+:=expl O:=_oad A:=_oad D:=_oad f=isfile \
+  zparseopts -a _opts P:=apre p:=hpre d:=dscrs X+:=expl O:=_oad A:=_oad D:=_oad f=isfile \
              i: S: s: I: x:=_mesg r: R: W: F: M+: E: q e Q n U C \
              J:=__ V:=__ a=__ l=__ k=__ o=__ 1=__ 2=__
 

--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -16,7 +16,7 @@ builtin unalias -m '[^+]*'
   local -a isfile _opts __ expl
   zparseopts -a _opts P:=apre p:=hpre d:=dscrs X+:=expl O:=_oad A:=_oad D:=_oad f=isfile \
              i: S: s: I: x:=_mesg r: R: W: F: M+: E: q e Q n U C \
-             J:=__ V:=__ a=__ l=__ k=__ o=__ 1=__ 2=__
+             J:=__ V:=__ a=__ l=__ k=__ o::=__ 1=__ 2=__
 
   # store $curcontext for further usage
   _ftb_curcontext=${curcontext#:}

--- a/test/fzftab.ztst
+++ b/test/fzftab.ztst
@@ -230,6 +230,14 @@
 >C1:{prefix_2}
 >C1:{prenofix_3}
 
+  comptesteval '_tst() { compadd -J packages -X package openpgp-keys-gentoo-release -MERGING-pnpm-bin }'
+  comptest $'tst \t'
+0:completions starts with dash
+>line: {tst }{}
+>QUERY:{}
+>C1:{package }
+>C1:{openpgp-keys-gentoo-release}
+>C1:{-MERGING-pnpm-bin}
 %clean
 
   zmodload -ui zsh/zpty


### PR DESCRIPTION
this fix following bugs:

```zsh
_tst() {
  compadd -J packages -X package openpgp-keys-gentoo-release -MERGING-pnpm-bin
}
compdef _tst tst
```