### PR TITLE
fix: prefix completion in quoted string

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -123,11 +123,10 @@ builtin unalias -m '[^+]*'
       fi
       ;;
     *)
-
       if (( ! _ftb_continue_last )) \
         && [[ $compstate[insert] == *"unambiguous" ]] \
         && [[ -n $compstate[unambiguous] ]] \
-        && [[ "$compstate[unambiguous]" != "$IPREFIX$PREFIX" ]]; then
+        && [[ "$compstate[unambiguous]" != "$compstate[quote]$IPREFIX$PREFIX$compstate[quote]" ]]; then
         compstate[list]=
         compstate[insert]=unambiguous
         _ftb_finish=1

--- a/test/fzftab.ztst
+++ b/test/fzftab.ztst
@@ -64,6 +64,15 @@
 0:unambiguous prefix
 >line: {: dir}{}
 
+  comptesteval '_tst() { compadd ".#abc" ".#def" ".#hij" }'
+  comptest $'tst ".#"\t'
+0:unambiguous prefix in quote string
+>line: {tst ".#abc }{"}
+>QUERY:{.#}
+>C0:{.#abc}
+>C0:{.#def}
+>C0:{.#hij}
+
   comptesteval '_tst() { compadd /home /usr /lib; compstate[insert]=menu }'
   comptest $'tst \t'
 0:force list


### PR DESCRIPTION
close #447

This behavior is different from compsys, but I think it is still worth fixing.