### PR TITLE
docs: add info about completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Replace zsh's default completion selection menu with fzf!
 >
 > 1. make sure [fzf](https://github.com/junegunn/fzf)  is installed
 > 2. fzf-tab needs to be loaded after `compinit`, but before plugins which will wrap widgets, such as [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) or [fast-syntax-highlighting](https://github.com/zdharma-continuum/fast-syntax-highlighting)
+> 3. Completions should be configured before `compinit`, as stated in the [zsh-completions manual installation guide](https://github.com/zsh-users/zsh-completions#manual-installation).
 
 ### Manual
 


### PR DESCRIPTION
This PR adds an important note to the documentation, specifying that completions must be set up before running `compinit`.

I spent several hours troubleshooting a problem where I thought `fzf-tab` was not working correctly. After a while, I realized that the issue was due to setting the `fpath` AFTER `compinit`. 
So in order to help users that manually install zsh plugins not to have the same issue, I added that note.