### PR TITLE
Remove text-coloring that interferes with fzf theming

### DIFF
--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -91,7 +91,6 @@ FZF_DEFAULT_OPTS=$fzf_default_opts SHELL=$ZSH_NAME $fzf_command \
   --ansi \
   --bind=$binds \
   --bind="${switch_group[1]}:reload($reload_command -1),${switch_group[2]}:reload($reload_command 1)" \
-  --color=hl:$(( header_lines == 0 ? 188 : 255 )) \
   --cycle \
   --delimiter='\x00' \
   --expect=$continuous_trigger,$print_query,$accept_line \

--- a/lib/-ftb-generate-complist
+++ b/lib/-ftb-generate-complist
@@ -9,7 +9,7 @@ local -A word_map=()
 (( $#_ftb_compcap == 0 )) && return
 
 -ftb-zstyle -s show-group show_group || show_group=full
--ftb-zstyle -s default-color default_color || default_color=$'\x1b[37m'
+-ftb-zstyle -s default-color default_color || default_color=''
 -ftb-zstyle -s prefix prefix || {
   zstyle -m ':completion:*:descriptions' format '*' && prefix='·'
 }


### PR DESCRIPTION
This PR is based on the thread of discussion in https://github.com/Aloxaf/fzf-tab/issues/477. The goal of this PR is to make it so that in order to theme fzf-tab with the same colors as your normal fzf theme, users can use just the following settings in their .zshrc:

```zsh
zstyle ':fzf-tab:*' use-fzf-default-opts yes
source ~/code/fzf-tab/fzf-tab.zsh
```

As fzf-tab works today, the required settings are:

```zsh
zstyle ':fzf-tab:*' use-fzf-default-opts yes
# necessary to override the hard-coded color flag passed to fzf by fzf-tab:
#
#     --color=hl:$(( header_lines == 0 ? 188 : 255 )) \ 
#
zstyle ':fzf-tab:*' fzf-flags --color=hl:myThemeColor
# necessary to replace the default value of \[37m, "hard white",
# which is used when there is only one completion group — which
# overrides any color values of `hl` or `hl+` being set in other fzf flags
#
#      -ftb-zstyle -s default-color default_color || default_color=$'\x1b[37m' 
#
zstyle ':fzf-tab:*' default-color ""
source ~/code/fzf-tab/fzf-tab.plugin.zsh
```

As a new user of fzf-tab, I am extremely grateful for this project. It works very well and between the fzf knowledge, shell knowledge, and c knowledge required to make it work so quickly, I am seriously impressed by the work that has gone into it. I am hoping that this change will make the user experience better by making it way easier to theme fzf-tab to look like any other fzf instance.

This would be a breaking change. I do not know the history of these default values, but the single-group default color has been \[37m since grouping was introduced, although it was originally known as `FZF_TAB_NO_GROUP_COLOR`: https://github.com/Aloxaf/fzf-tab/pull/23/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R121

I generally believe that PRs to update default themes/colors should be rejected by maintainers by default, but in this case I'd like you to consider that these changes only make it easier to customize fzf-tab's theme and make it look the way the user wants, by removing defaults present in the project.

I tested this change by using these zshrc settings, and observing that the fzf style matched my default fzf theme as expected, in both light mode and in dark mode:

```zsh
zstyle ':fzf-tab:*' use-fzf-default-opts yes
source ~/code/fzf-tab/fzf-tab.plugin.zsh
```

If this PR is accepted as-is, [the wiki entry for `default-color`](https://github.com/Aloxaf/fzf-tab/wiki/Configuration#default-color) will also need to be updated.