### PR TITLE
Avoid spawning a subshell in `-ftb-compadd`

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -25,7 +25,7 @@ builtin unalias -m '[^+]*'
   # or fzf-tab is disabled in the current context
   if (( $#_oad != 0 || ! IN_FZF_TAB )) \
     || { -ftb-zstyle -m disabled-on "any" } \
-    || ({ -ftb-zstyle -m disabled-on "files" } && [[ -n $isfile ]]); then
+    || { -ftb-zstyle -m disabled-on "files" && [[ -n $isfile ]] }; then
     builtin compadd "$@"
     return
   fi


### PR DESCRIPTION
Subshells cause zsh to try and render their prompt. For reasons I do not entirely understand, zsh does not expand `$PROMPT` correctly in this case when PROMPT_SUBST is set.

Fortunately, using a brace group instead of a subshell is simple and has the same meaning.

Fixes #513 