### PR TITLE
Use shell parsing to split fzf-command into words

### DIFF
--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -87,7 +87,7 @@ if [[ "$use_fzf_default_opts" == "yes" ]]; then
   fzf_default_opts=$FZF_DEFAULT_OPTS
 fi
 
-FZF_DEFAULT_OPTS=$fzf_default_opts SHELL=$ZSH_NAME $fzf_command \
+FZF_DEFAULT_OPTS=$fzf_default_opts SHELL=$ZSH_NAME ${(z)fzf_command} \
   --ansi \
   --bind=$binds \
   --bind="${switch_group[1]}:reload($reload_command -1),${switch_group[2]}:reload($reload_command 1)" \


### PR DESCRIPTION
Small change only to apply the `(z)` flag when expanding the `fzf_command` parameter. This allows for proper command lists to be provided e.g.

```shell
zstyle ':fzf-tab:*' fzf-command 'env SOME_VAR=foo fzf'`
```

Without this change, the above fails with:

```shell
zsh: command not found: env SOME_VAR =foo fzf ...
```