### PR TITLE
Support retaining `${group}` values while not displaying group headers

### DIFF
--- a/lib/-ftb-generate-header
+++ b/lib/-ftb-generate-header
@@ -4,6 +4,11 @@ typeset -ga _ftb_headers=()
 local i tmp group_colors
 local -i mlen=0 len=0
 
+# Keep ${group} value for preview, binds, etc without displaying group headers
+if { -ftb-zstyle -m show-group "quiet" }; then
+  return
+fi
+
 if (( $#_ftb_groups == 1 )) && { ! -ftb-zstyle -m single-group "header" }; then
   return
 fi


### PR DESCRIPTION
This commit adds a new `show-group` style value: `quiet` [^naming] .

Specifying this option prevents any group headers from displaying in the completion list, while still providing the `${group}` value(s) to FZF preview/shell commands. This is an alternative to `show-group none` where no headers are shown, but all `${group}` values are replaced by `__hide__`.



[^naming]: I initially used `show-group hide` before I remembered `__hide__` is in use with `show-group none`.


----

Consider the following zstyles:

<details><summary>Details</summary>
<p>


```shell
zstyle ':fzf-tab:*:file:*' fzf-flags --height=~80% --style=full --query='!^.' --header-label=' File Type '
zstyle ':fzf-tab:*:file:*' fzf-bindings 'focus:transform-header(
    {_FTB_INIT_} {
        file -LIb ${realpath} || echo "No file selected";
        exiftool -m -fast -printFormat '' ${ImageWidth}x${ImageHeight}'' -i ${realpath} ${realpath}
    } | paste -d ";" - -
)'
zstyle ':fzf-tab:*:file:*' fzf-preview '
  case "${group}" in
    *external*)
      bat --color=always --style=full "${commands[${word}]}"
      ;;
    *command*|*function*)
      which -x4 ${word} | bat --color=always -plsh
      ;;
    *alias)
      command -v ${word} | bat --color=always -plzsh
      ;;
    *parameter)
      typeset -p1 ${word} | bat --color=always -plzsh
      ;;
    *directory)
      eza -aTL3 --color=always --group-directories-first --show-symlinks ${realpath}
      ;;
    expansions|file*)
      [[ $(file -LIb ${realpath}) =~ image* ]] \
        && kitten icat --clear --unicode-placeholder --stdin=no --transfer-mode=memory --place="${FZF_PREVIEW_COLUMNS}x${FZF_PREVIEW_LINES}@0x0" ${realpath} \
        || bat --color=always ${realpath}
      ;;
    preset)
      fastfetch -c ${word}
      ;;
    *)
      echo "${word}=${(P)word}" ;;
  esac
'
```


</p>
</details> 


Now some different values of `show-group`.


#### show-group full

Notice how in the `File Type` box there are two lines instead of one. The second line contains the completion groups, but at least the preview is working.

https://github.com/user-attachments/assets/530ed449-5bac-4e79-a94d-696cc279e85b


#### show-group none

We want to get rid of the group headers in our `File Type` box, so we set `show-group none`. Unfortunately, in doing so, we break the preview output.

https://github.com/user-attachments/assets/ec727f56-0829-4d91-a5f8-fe670291dd4e


#### show-group quiet

New style configuration to solve this problem. Notice how we get rid of the group headers while maintaining the preview functionality.

https://github.com/user-attachments/assets/2af02ad9-9204-43fb-af88-d193335cd204


