### PR TITLE
Properly Handle `ln` Coloring in `colorize_from_mode`

### DIFF
--- a/modules/Src/fzftab.c
+++ b/modules/Src/fzftab.c
@@ -176,6 +176,8 @@ const char* colorize_from_mode(char* file, const struct stat* sb)
                 return mode_color[COL_OR];
             }
             return get_color(file, &sb2);
+        } else {
+          return mode_color[COL_LN];
         }
     }
     case S_IFIFO:


### PR DESCRIPTION
# Bug Fix: Properly Handle `ln` Coloring in `colorize_from_mode`

## Summary

This pull request fixes a bug in `fzf-tab` where symbolic links (`ln`) were not properly colorized when `LS_COLORS` defined `ln` as a specific color rather than `"target"`.

## Problem

In the function `colorize_from_mode` (`./modules/Src/fzftab.c`), the logic for handling symbolic links assumed that `ln` would always be set to `"target"`. When this wasn’t the case (e.g., if `LS_COLORS` explicitly specified a color for `ln`), the function skipped applying the correct color, leaving symbolic links incorrectly colored.

## Root Cause

The `else` branch was missing in the `S_IFLNK` case. Without it, symbolic links with a color explicitly set in `LS_COLORS` were not handled correctly.

```c
case S_IFLNK: {
    if (strpfx(mode_color[COL_LN], "target")) {
        if (stat(file, &sb2) == -1) {
            return mode_color[COL_OR];
        }
        return get_color(file, &sb2);
    } else { // Missing else caused the bug
        return mode_color[COL_LN];
    }
}
```

## Fix

Added the missing `else` clause to return `mode_color[COL_LN]` when `ln` is explicitly set to a color.  
This ensures symbolic links are properly colorized in both cases:

* When `ln=target` (use the target’s color)
* When `ln` is assigned a direct color value in `LS_COLORS`

## Impact

* Users with `LS_COLORS` configured with `ln=target` see no change (still works as before).
* Users with `LS_COLORS` configured with `ln=<color>` now see symbolic links correctly colorized.

## Testing

* Verified with `LS_COLORS="ln=target"`: symlink colors match their targets.
* Verified with `LS_COLORS="ln=36"` (cyan): symlinks are consistently colored cyan.
