### PR TITLE
fix: fzf --style=default popup height handling

### DIFF
--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -63,7 +63,7 @@ comp_length=$(( comp_length + $popup_pad[1] ))
 local popup_height popup_y popup_width popup_x adjust_height
 
 # adjust the popup height if the fzf finder info style is not default
-if (( $fzf_opts[(I)--info=*(hidden|inline)*] > 0 )); then
+if (( $fzf_opts[(I)--info=*(hidden|inline)*] > 0 && $fzf_opts[(I)--style=*(minimal|full)*] > 0 )); then
     adjust_height=-1
 fi
 


### PR DESCRIPTION
This change makes it so that the popup height is only adjusted when both the finder info style is set to `hidden` or `inline` and the style is set to `minimal` or `full`.

Without this, when fzf style is set to default, there is always one line that doesn't fit in the popup and you need to scroll.