### PR TITLE
feat: ftb-tmux-popup max-width and max-height

### DIFF
--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -41,10 +41,12 @@ if (( ! $+IN_FZF_TAB )); then
   cat > $tmp_dir/completions.$$
 fi
 
-local text REPLY comp_lines comp_length length popup_pad popup_min_size
+local text REPLY comp_lines comp_length length popup_pad popup_min_size popup_max_width popup_max_height
 
 zstyle -a ":fzf-tab:$_ftb_curcontext" popup-pad popup_pad || popup_pad=(0 0)
 zstyle -a ":fzf-tab:$_ftb_curcontext" popup-min-size popup_min_size || popup_min_size=(0 0)
+zstyle -s ":fzf-tab:$_ftb_curcontext" popup-max-height popup_max_height || popup_max_height=$window_height
+zstyle -s ":fzf-tab:$_ftb_curcontext" popup-max-width popup_max_width || popup_max_width=$window_width
 
 # get the size of content, note we should remove all ANSI color code
 comp_lines=$(( ${#${(f)mapfile[$tmp_dir/completions.$$]}} + $popup_pad[2] ))
@@ -70,7 +72,7 @@ fi
 # calculate the popup height and y position
 if (( cursor_y * 2 > window_height )); then
   # show above the cursor
-  popup_height=$(( min(max(comp_lines + 4, popup_min_size[2]), cursor_y - window_top) + adjust_height ))
+  popup_height=$(( min(max(min(comp_lines, popup_max_height) + 4, popup_min_size[2]), cursor_y - window_top) + adjust_height ))
   popup_y=$cursor_y
   if zstyle -T ":fzf-tab:$_ftb_curcontext" popup-smart-tab; then
     fzf_opts+=(--bind=tab:up,btab:down)
@@ -78,13 +80,13 @@ if (( cursor_y * 2 > window_height )); then
   fzf_opts+=(--layout=default)
 else
   # show below the cursor
-  popup_height=$(( min(max(comp_lines + 4, popup_min_size[2]), window_height - cursor_y + window_top - 1) + adjust_height ))
+  popup_height=$(( min(max(min(comp_lines, popup_max_height) + 4, popup_min_size[2]), window_height - cursor_y + window_top - 1) + adjust_height ))
   popup_y=$(( cursor_y + popup_height + 1 ))
   fzf_opts+=(--layout=reverse)
 fi
 
 # calculate the popup width and x position
-popup_width=$(( min(max(comp_length + 5, popup_min_size[1]), window_width) ))
+popup_width=$(( min(min(max(comp_length + 5, popup_min_size[1]), window_width), popup_max_width) ))
 popup_x=$(( cursor_x + popup_width > window_width ? window_width - popup_width : cursor_x ))
 
 echo -E "env FZF_DEFAULT_OPTS=${(qq)FZF_DEFAULT_OPTS} SHELL=$ZSH_NAME $commands[fzf] ${(qq)fzf_opts[@]} < $tmp_dir/completions.$$ > $tmp_dir/result-$$" > $tmp_dir/fzf-$$


### PR DESCRIPTION
This pull request introduces support for configurable maximum popup height and width. 

This essentially acts like --height=~$popup-max-size in non-tmux fzf, so one can configure how many completions they wanna see at once instead of it always taking up the whole screen. 

I also added max-width, because for both popup-pad and popup-min-size you can configure it, although I don't really know whether that would actually be useful to anyone, let me know your thoughts.