### PR TITLE
Increased robustness for cat in fzf completions

### DIFF
--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -70,7 +70,7 @@ if (( ! use_tmux_popup )); then
   echoti cnorm >/dev/tty 2>/dev/null
 fi
 
-cat > $tmp_dir/completions.$$
+command cat > $tmp_dir/completions.$$
 
 local dd='gdd'
 if (( ${+commands[$dd]} == 0 )) ; then


### PR DESCRIPTION
When users have defined a function overwriting cat to bat, if some colourization of the completions is used, a file reader such as bat will fail, as the file contains null bytes. Swapping this to cat to command cat will stop this failure from happening