### PR TITLE
Refactor: Only source ls-colors.zsh when fzftab module isn't loaded

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -386,8 +386,6 @@ zmodload -F zsh/stat b:zstat
 0="${${(M)0:#/*}:-$PWD/$0}"
 FZF_TAB_HOME="${0:A:h}"
 
-source "$FZF_TAB_HOME"/lib/zsh-ls-colors/ls-colors.zsh fzf-tab-lscolors
-
 typeset -ga _ftb_group_colors=(
   $'\x1b[94m' $'\x1b[32m' $'\x1b[33m' $'\x1b[35m' $'\x1b[31m' $'\x1b[38;5;27m' $'\x1b[36m'
   $'\x1b[38;5;100m' $'\x1b[38;5;98m' $'\x1b[91m' $'\x1b[38;5;80m' $'\x1b[92m'
@@ -397,6 +395,10 @@ typeset -ga _ftb_group_colors=(
 # init
 () {
   emulate -L zsh -o extended_glob
+  
+  # Ensure we don't keep a stale value around
+  # and allow the aloxaf/fzftab module to set it when loaded.
+  unset FZF_TAB_MODULE_VERSION 2>/dev/null
 
   if (( ! $fpath[(I)$FZF_TAB_HOME/lib] )); then
     fpath+=($FZF_TAB_HOME/lib)
@@ -413,7 +415,7 @@ typeset -ga _ftb_group_colors=(
 
   if [[ -n $FZF_TAB_HOME/modules/Src/aloxaf/fzftab.(so|bundle)(#qN) ]]; then
     module_path+=("$FZF_TAB_HOME/modules/Src")
-    zmodload aloxaf/fzftab
+    zmodload aloxaf/fzftab # if this fails, we fall back to ls-colors.zsh below
 
     if [[ $FZF_TAB_MODULE_VERSION != "0.2.2" ]]; then
       zmodload -u aloxaf/fzftab
@@ -426,6 +428,9 @@ typeset -ga _ftb_group_colors=(
       fi
     fi
   fi
+
+  # Only needed when the module is not available (or failed to load).
+  [[ $FZF_TAB_MODULE_VERSION = "0.2.2" ]] || source "$FZF_TAB_HOME"/lib/zsh-ls-colors/ls-colors.zsh fzf-tab-lscolors
 }
 
 enable-fzf-tab


### PR DESCRIPTION
**Motivation**  

fzf-tab sources `lib/zsh-ls-colors/ls-colors.zsh` unconditionally. However, when the `aloxaf/fzftab` module is present and successfully loaded, filename coloring is performed directly by zsh through the module, so sourcing `ls-colors.zsh` is redundant.

**What this PR does**

* Unsets `FZF_TAB_MODULE_VERSION` at init to avoid stale values influencing the logic.
* Attempts to load `aloxaf/fzftab` (and keeps the existing rebuild/version-check logic).
* Sources `ls-colors.zsh` only if the module is not available or fails to load.

**Result**  

No behavior change for users without the module; less work at startup for users with a working `aloxaf/fzftab` module.
