### PR TITLE
Fix: reload fzftab module on re-source (follow-up to merged #555)

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -396,8 +396,11 @@ typeset -ga _ftb_group_colors=(
 () {
   emulate -L zsh -o extended_glob
   
-  # Ensure we don't keep a stale value around
-  # and allow the aloxaf/fzftab module to set it when loaded.
+  # Re-source should fully reinitialize; unload the module so boot_ runs again.
+  if zmodload -e aloxaf/fzftab; then
+    zmodload -u aloxaf/fzftab &>/dev/null
+  fi
+  # Ensure we don't keep a stale value around and allow the module to set it.
   unset FZF_TAB_MODULE_VERSION 2>/dev/null
 
   if (( ! $fpath[(I)$FZF_TAB_HOME/lib] )); then


### PR DESCRIPTION
# PR Summary

This follow-up to Aloxaf/fzf-tab#555 fixes a re-source edge case when the binary module is already loaded. Re-sourcing `fzf-tab.plugin.zsh` now unloads `aloxaf/fzftab`, clears `FZF_TAB_MODULE_VERSION`, and then reloads the module so `boot_` in fzftab.c runs and the version parameter is repopulated. This prevents the false rebuild prompt that happened when the module was preloaded but the version variable was unset.

## Why

- Re-sourcing should reinitialize the plugin cleanly.
- If the module is already loaded, `boot_` does not rerun, so the version
  parameter is not restored after being unset.
- This led to a spurious rebuild prompt despite a valid module being present.

## What Changed

- Detect a preloaded `aloxaf/fzftab` module during init.
- Unload it quietly (`zmodload -u ... &>/dev/null`), then unset
  `FZF_TAB_MODULE_VERSION` so the subsequent `zmodload` sets it again.

## Testing

- Re-sourced `fzf-tab.plugin.zsh` with the module already loaded and confirmed
  no rebuild prompt and no unload message.
