### PR TITLE
Fix: sorts completion candidates to present a stable, predictable list

### DIFF
--- a/lib/-ftb-generate-complist
+++ b/lib/-ftb-generate-complist
@@ -83,11 +83,12 @@ fi
 # sort and remove sort group or other index
 zstyle -T ":completion:$_ftb_curcontext" sort
 if (( $? != 1 )); then
+  local LC_ALL=C
   if (( colorful )); then
     # if enable list_colors, we should skip the first field
     if [[ ${commands[sort]:A:t} != (|busybox*) ]]; then
       # this is faster but doesn't work if `find` is from busybox
-      tcandidates=(${(f)"$(command sort -u -t '\0' -k 2 <<< ${(pj:\n:)tcandidates})"})
+      tcandidates=(${(f)"$(LC_ALL=C command sort -u -t '\0' -k 2 <<< ${(pj:\n:)tcandidates})"})
     else
       # slower but portable
       tcandidates=(${(@o)${(@)tcandidates:/(#b)([^$'\0']#)$'\0'(*)/$match[2]$'\0'$match[1]}})


### PR DESCRIPTION
### Ensure stable candidate ordering across locales

This PR makes completion ordering deterministic by forcing `LC_ALL=C` during candidate sorting inside `lib/-ftb-generate-complist`.

#### Motivation

`fzf-tab` sorts completion candidates to present a stable, predictable list. Today, that sort inherits the user’s locale (e.g., `LC_ALL=en_US.UTF-8`). Collation rules vary across locales, so the same set of candidates can appear in a different order on different machines.

This matters most for candidates that include characters which need escaping in completion display. For example, a filename that literally contains backticks:

```
 dir`notes`
```

You can create this safely with quoting so the backticks are literal, not executed:

```zsh
touch 'dir`notes`'
```

In the completion list, Zsh displays this with backslashes (e.g., `dir\`notes\``) to avoid command substitution. Under some locales, that escaped entry can sort *before* simple names like `dir1/` and `dir2/`, while under `C` collation it sorts *after* them. That means the “first item” depends on the locale, which breaks reproducibility and makes test output (and user expectations) inconsistent across systems.

#### Change

We set `LC_ALL=C` only for the sorting step:

- Zsh’s internal `tcandidates` sorting now uses the C collation order.
- When GNU `sort` is used for colorful lists, it is invoked with `LC_ALL=C` as well.

This keeps the *content* of the completion list exactly the same, but makes its *order* stable across locales.

#### Why this is safe

- The change is limited to sorting; it doesn’t affect matching, filtering, or insertion.
- It aligns with the existing intent: predictable ordering regardless of environment.
- It only applies to the completion list generation stage, not global shell behavior.

#### Example

Given candidates:

```
 dir1/
 dir2/
 dir`notes`  # literal backticks in the filename
```

With locale-dependent sorting, the escaped entry can surface first. With `LC_ALL=C`, it consistently sorts after the plain names, producing a stable order on any system.

#### Tests

All existing tests continue to pass. This change mainly prevents locale-specific ordering differences that can show up in CI or in users’ environments.
