### PR TITLE
Fix: resolved bug where a local `keys` array in -ftb-compadd shadowed…

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -51,9 +51,9 @@ builtin unalias -m '[^+]*'
   [[ -n $expl ]] && _ftb_groups+=$expl
 
   # store these values in _ftb_compcap
-  local -a keys=(apre hpre PREFIX SUFFIX IPREFIX ISUFFIX)
+  local -a _ftb_compcap_keys=(apre hpre PREFIX SUFFIX IPREFIX ISUFFIX)
   local key expanded __tmp_value=$'<\0>' # placeholder
-  for key in $keys; do
+  for key in $_ftb_compcap_keys; do
     expanded=${(P)key}
     if [[ -n $expanded ]]; then
       __tmp_value+=$'\0'$key$'\0'$expanded


### PR DESCRIPTION
### Fix associative subscript completion broken by local `keys` shadowing

This PR fixes a long‑standing completion bug in `fzf-tab` where associative array subscripts could complete to unrelated tokens like `PREFIX`, even when those are not real keys.

#### Root cause

Inside `-ftb-compadd`, we declared a local array named `keys` to capture metadata fields (`PREFIX`, `SUFFIX`, `IPREFIX`, `ISUFFIX`, etc.) for fzf-tab’s internal completion capture.

However, Zsh’s associative subscript completion uses `compadd -a keys` and expects a `keys` array from the completer context (containing the actual associative keys). Because `-ftb-compadd` runs in the same dynamic scope, our local `keys` shadowed that array. As a result, completion candidates were taken from our internal metadata list, not the real associative keys.

#### Symptom

Example (no `_approximate` needed):

```zsh
typeset -A ZINIT
ZINIT[PLUGIN_DIR]=/tmp/plugin
ZINIT[PLUGINS_DIR]=/tmp/plugins

# Pressing TAB here could insert PREFIX (not a real key):
echo $ZINIT[P<TAB>
```

Instead of completing to `PLUGIN...`, it could insert `PREFIX` because that was one of the internal metadata field names.

#### Fix

Rename the internal array from `keys` to `_ftb_compcap_keys` in `-ftb-compadd` to avoid the name collision. This restores correct associative key completion without changing any completion logic or behavior for other paths.

#### Compatibility

All existing tests continue to pass.
