### PR TITLE
fix: preserve `FZF_TAB_MODULE_VERSION` when module is already loaded (fix-up #555)

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -395,10 +395,13 @@ typeset -ga _ftb_group_colors=(
 # init
 () {
   emulate -L zsh -o extended_glob
-  
-  # Ensure we don't keep a stale value around
-  # and allow the aloxaf/fzftab module to set it when loaded.
-  unset FZF_TAB_MODULE_VERSION 2>/dev/null
+
+  # Ensure we don't keep a stale value around.
+  # If the module is loaded, the variable is valid; unsetting would lose it
+  # since zmodload won't reload an already-loaded module.
+  if ! zmodload -e aloxaf/fzftab; then
+    unset FZF_TAB_MODULE_VERSION 2>/dev/null
+  fi
 
   if (( ! $fpath[(I)$FZF_TAB_HOME/lib] )); then
     fpath+=($FZF_TAB_HOME/lib)


### PR DESCRIPTION
## Summary

Fixes #555 - a regression where `FZF_TAB_MODULE_VERSION` is lost when re-sourcing `fzf-tab.zsh`.

**The problem:** #555 unconditionally unsets `FZF_TAB_MODULE_VERSION` on every source. However, `zmodload` doesn't reload an already-loaded module, so the boot callback that sets this variable never runs again. Result: the variable is permanently lost after re-sourcing.

**The fix:** Only unset the variable when the module is *not* loaded. If it's already loaded, the existing value is valid and should be preserved.

## Why this approach and a duplicate of PR #556?

The PR #556 proposes a different approach in resolving the same issue by unloading the module (`zmodload -u`) before reloading. While that also solves the problem, this PR's approach is better because:

   | Aspect | This PR | #556 |
   |--------|---------|------|
   | Operation | Conditional `unset` only | Full module unload + reload |
   | Performance | Minimal overhead | Higher cost |
   | Side effects | None | Resets any module state |
   | Complexity | Simple check | More invasive |

   The conservative approach here preserves existing behavior and only changes what's strictly necessary to fix the bug.