### PR TITLE
fix: append SGR reset to dsuf to prevent background color bleed

### DIFF
--- a/lib/-ftb-colorize
+++ b/lib/-ftb-colorize
@@ -28,7 +28,8 @@ if [[ -n $lstat[14] ]]; then
     rsv_color=$REPLY
   fi
   dpre=$'\033[0m\033['$sym_color'm'
-  dsuf+=$'\033[0m -> \033['$rsv_color'm'$rsv
+  dsuf+=$'\033[0m -> \033['$rsv_color'm'$rsv$'\033[0m'
 else
   dpre=$'\033[0m\033['$REPLY'm'
+  dsuf=$'\033[0m'$dsuf
 fi


### PR DESCRIPTION
## Summary

Fixes #563.

In `lib/-ftb-colorize`, the ANSI color sequence opened in `dpre` is never terminated in `dsuf`, causing background colors (e.g. from [vivid](https://github.com/sharkdp/vivid)'s LS_COLORS themes) to bleed into the first character of the following entry in the fzf list.

### Changes

- **Symlink branch**: append `\033[0m` after the resolved path in `dsuf`
- **Non-symlink branch**: prepend `\033[0m` to `dsuf`

```diff
   dpre=$'\033[0m\033['$sym_color'm'
-  dsuf+=$'\033[0m -> \033['$rsv_color'm'$rsv
+  dsuf+=$'\033[0m -> \033['$rsv_color'm'$rsv$'\033[0m'
 else
   dpre=$'\033[0m\033['$REPLY'm'
+  dsuf=$'\033[0m'$dsuf
 fi
```

> **Note:** The C module (`fzf-tab-candidates-generate` builtin) already appends `\033[0m` to `dsuf` in `fzftab.c:454`, so it is unaffected by this bug.