### PR TITLE
Try using gnudd instead of dd if it exists

### DIFF
--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -75,6 +75,9 @@ command cat > $tmp_dir/completions.$$
 
 local dd='gdd'
 if (( ${+commands[$dd]} == 0 )) ; then
+  dd='gnudd'
+fi
+if (( ${+commands[$dd]} == 0 )) ; then
   dd='dd'
 fi
 if (( ${+commands[$dd]} == 0 )) ; then


### PR DESCRIPTION
After `gdd` (which I assume is for MacOS), try `gnudd` (for Ubuntu systems where uutils is installed) before falling back onto standard `dd`.

Fixes: #549
