### PR TITLE
Workaround bugs in dd from uutils

### DIFF
--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -81,7 +81,7 @@ if (( ${+commands[$dd]} == 0 )) ; then
   dd='true' # nop if dd is not installed
 fi
 
-_ftb_query="${_ftb_query}$(command "$dd" bs=1G count=1 status=none iflag=nonblock < /dev/tty 2>/dev/null)" || true
+_ftb_query="${_ftb_query}$(command "$dd" bs=4K count=2617344 status=none iflag=nonblock if=/dev/tty 2>/dev/null)" || true
 
 local fzf_default_opts=''
 if [[ "$use_fzf_default_opts" == "yes" ]]; then


### PR DESCRIPTION
uutils dd [doesn't apply nonblock to an inherited fd 0](https://github.com/uutils/coreutils/issues/11543). Changing from `< /dev/tty` to `if=/dev/tty` works around that because uutils dd does apply nonblock on the `openat` syscall which it uses for `if=`.

uutils dd [takes a long time to allocate memory for large `bs` numbers](https://github.com/uutils/coreutils/issues/11544). Changing to a block size of `4K` seems to fix it, and also reduces the memory requirements of fzf-tab (`1GB` buffer size is a little absurd, this affects even GNU dd, just that it doesn't take as long to allocate memory).

Fixes: #549
