### PR TITLE
Fix subsequence-based unambiguous completion

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -131,6 +131,20 @@ builtin unalias -m '[^+]*'
   zstyle $1 ":fzf-tab:$_ftb_curcontext" ${@:2}
 }
 
+-ftb-unambiguous-is-contiguous() {
+  emulate -L zsh -o extended_glob
+  local unambiguous="${1##*/}" entry word bs=$'\2'
+  local -A capture
+  shift
+
+  [[ -n $unambiguous ]] || return 1
+  for entry in "$@"; do
+    capture=("${(@0)${entry#*$bs}}")
+    word="${capture[word]-${entry%%$bs*}}"
+    [[ $word == *$unambiguous* ]] || return 1
+  done
+}
+
 -ftb-complete() {
   local -Ua _ftb_groups
   local choice choices _ftb_curcontext continuous_trigger print_query accept_line bs=$'\2' nul=$'\0'
@@ -168,10 +182,12 @@ builtin unalias -m '[^+]*'
         && [[ -n $compstate[unambiguous] ]] \
         && [[ "$compstate[unambiguous]" != "$compstate[quote]$IPREFIX$PREFIX$compstate[quote]" ]] \
         && [[ $compstate[list] != *"force"* ]]; then
-        compstate[list]=
-        compstate[insert]=unambiguous
-        _ftb_finish=1
-        return 0
+        if -ftb-unambiguous-is-contiguous "$compstate[unambiguous]" "${_ftb_compcap[@]}"; then
+          compstate[list]=
+          compstate[insert]=unambiguous
+          _ftb_finish=1
+          return 0
+        fi
       fi
 
       -ftb-generate-query      # sets `_ftb_query`

--- a/test/fzftab.ztst
+++ b/test/fzftab.ztst
@@ -180,6 +180,17 @@
 0:matcher-list
 >line: {: vim.coc }{}
 
+  comptesteval "zstyle ':completion:*' menu no; zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|=*' 'l:|=* r:|=*'"
+  comptesteval "mkdir -p somedir/project_alpha_1234_final somedir/project_al_pha_benchmark_1234"
+  comptest $': somedir/_1234\t'
+  comptesteval "rm -r somedir; zstyle ':completion:*' menu true; zstyle -d ':completion:*' matcher-list"
+0:matcher-list subsequence unambiguous falls through
+>line: {: somedir/project_al_pha_benchmark_1234/}{}
+>QUERY:{project_al}
+>DESCRIPTION:{file}
+>C1:{project_al_pha_benchmark_1234/}
+>C1:{project_alpha_1234_final/}
+
   comptesteval $'cd dir1'
   comptest $': ../d\t'
   comptesteval $'cd ..'
@@ -251,4 +262,3 @@
 %clean
 
   zmodload -ui zsh/zpty
-


### PR DESCRIPTION
## Summary

When `matcher-list` enables subsequence matching, zsh can compute a `compstate[unambiguous]` value that is not a contiguous substring of every candidate. fzf-tab currently trusts that value and inserts it, which can bias completion toward one candidate instead of showing the fzf menu.

This change validates the unambiguous insertion against the captured completion words first. If the proposed insertion is not contiguous in every matched word, fzf-tab falls through to the normal fzf candidate list.

Closes #560.

## Tests

- `zsh -n fzf-tab.zsh test/fzftab.ztst test/runtests.zsh test/comptest`
- `cd test && zsh runtests.zsh fzftab.ztst`
- Verified the new regression fails on current upstream by inserting `somedir/k_1234`, and passes with this patch by showing both candidates.