### PR TITLE
fix: preserve realpath for execute bindings

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -509,7 +509,11 @@ typeset -ga _ftb_group_colors=(
   fi
 
   if (( ! $fpath[(I)$FZF_TAB_HOME/lib] )); then
-    fpath+=($FZF_TAB_HOME/lib)
+    # Prepend so autoloaded helpers (-ftb-*) always come from this plugin copy.
+    # Appending can pick stale helpers from another fpath entry when multiple
+    # fzf-tab copies exist (e.g. plugin manager leftovers), causing mismatched
+    # runtime behavior.
+    fpath=($FZF_TAB_HOME/lib $fpath)
   fi
 
   autoload -Uz is-at-least -- $FZF_TAB_HOME/lib/-#ftb*(:t)

--- a/lib/-ftb-fzf
+++ b/lib/-ftb-fzf
@@ -50,7 +50,7 @@ local normalized_active_group_style=${${(j:,:)_active_style_sorted}:-none}
 
 print -rl -- $_ftb_compcap > $tmp_dir/compcap.$$
 print -rl -- $_ftb_groups  > $tmp_dir/groups.$$
-print -r -- ${ftb_preview_init/{f}/\$1} > $tmp_dir/ftb_preview_init.$$
+print -r -- ${ftb_preview_init//\{f\}/\$1} > $tmp_dir/ftb_preview_init.$$
 
 binds=${binds//{_FTB_INIT_}/. $tmp_dir/ftb_preview_init.$$ {f} $'\n'}
 

--- a/lib/-ftb-preview.tpl
+++ b/lib/-ftb-preview.tpl
@@ -4,7 +4,10 @@ local -a _ftb_groups=("${(@f)mapfile[__FTB_GROUPS__]}")
 local bs=$'\2'
 
 # get description
-export desc=${${"$(<'{f}')"%$'\0'*}#*$'\0'}
+# NOTE: keep {f} unquoted here so -ftb-fzf can rewrite it to $1 for {_FTB_INIT_}.
+# Quoting it (e.g. '{f}') would turn rewritten '$1' into a literal string.
+local _ftb_cur_file={f}
+export desc=${${"$(<$_ftb_cur_file)"%$'\0'*}#*$'\0'}
 # get ctxt for current completion
 local -A ctxt=("${(@0)${_ftb_compcap[(r)${(b)desc}$bs*]#*$bs}}")
 # get group


### PR DESCRIPTION
Fixes the empty $realpath behavior.

This is done with Codex, for my working-with-AI purposes. It fixes the issue in my local installation. Feel free to reject it.

(Thanks for fzf-tab, I love it!)