### PR TITLE
fix(ftb-tmux-popup): strip --tmux/--popup from FZF_DEFAULT_OPTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.zwc
+.zcompdump

--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -29,16 +29,9 @@ fzf_opts=(${${fzf_opts/--height*}/--layout*})
 # Strip --tmux/--popup from FZF_DEFAULT_OPTS before it reaches fzf inside the
 # popup: with use-fzf-default-opts yes, fzf would otherwise open a second
 # (nested) popup inside the outer `tmux popup -E` (see #455, #509).
-ftb-tmux-popup-strip-fdo() {
-  emulate -L zsh -o extended_glob
-  local _ftb_fdo=${1:-}
-  if [[ -n $_ftb_fdo ]]; then
-    local -a _ftb_fdo_opts=(${(z)_ftb_fdo})
-    _ftb_fdo=${(j: :)_ftb_fdo_opts:#--(tmux|popup)*}
-  fi
-  print -r -- "$_ftb_fdo"
-}
-local _ftb_fdo=$(ftb-tmux-popup-strip-fdo "$FZF_DEFAULT_OPTS")
+# ${array:#pattern} filters the array as a whole and drops matching elements.
+local -a _ftb_fdo_opts=(${(z)FZF_DEFAULT_OPTS})
+local _ftb_fdo=${(j: :)_ftb_fdo_opts:#--(tmux|popup)*}
 
 # get position of cursor and size of window
 local -a tmp=($(command tmux display-message -p "#{pane_top} #{cursor_y} #{pane_left} #{cursor_x} #{window_height} #{window_width} #{status} #{status-position}"))

--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -26,6 +26,20 @@ local ret=0
 local -a fzf_opts=($@)
 fzf_opts=(${${fzf_opts/--height*}/--layout*})
 
+# Strip --tmux/--popup from FZF_DEFAULT_OPTS before it reaches fzf inside the
+# popup: with use-fzf-default-opts yes, fzf would otherwise open a second
+# (nested) popup inside the outer `tmux popup -E` (see #455, #509).
+ftb-tmux-popup-strip-fdo() {
+  emulate -L zsh -o extended_glob
+  local _ftb_fdo=${1:-}
+  if [[ -n $_ftb_fdo ]]; then
+    local -a _ftb_fdo_opts=(${(z)_ftb_fdo})
+    _ftb_fdo=${(j: :)_ftb_fdo_opts:#--(tmux|popup)*}
+  fi
+  print -r -- "$_ftb_fdo"
+}
+local _ftb_fdo=$(ftb-tmux-popup-strip-fdo "$FZF_DEFAULT_OPTS")
+
 # get position of cursor and size of window
 local -a tmp=($(command tmux display-message -p "#{pane_top} #{cursor_y} #{pane_left} #{cursor_x} #{window_height} #{window_width} #{status} #{status-position}"))
 local cursor_y=$((tmp[1] + tmp[2])) cursor_x=$((tmp[3] + tmp[4])) window_height=$tmp[5] window_width=$tmp[6] window_top=0
@@ -87,7 +101,7 @@ fi
 popup_width=$(( min(max(comp_length + 5, popup_min_size[1]), window_width) ))
 popup_x=$(( cursor_x + popup_width > window_width ? window_width - popup_width : cursor_x ))
 
-echo -E "env FZF_DEFAULT_OPTS=${(qq)FZF_DEFAULT_OPTS} SHELL=$ZSH_NAME $commands[fzf] ${(qq)fzf_opts[@]} < $tmp_dir/completions.$$ > $tmp_dir/result-$$" > $tmp_dir/fzf-$$
+echo -E "env FZF_DEFAULT_OPTS=${(qq)_ftb_fdo} SHELL=$ZSH_NAME $commands[fzf] ${(qq)fzf_opts[@]} < $tmp_dir/completions.$$ > $tmp_dir/result-$$" > $tmp_dir/fzf-$$
 {
   tmux popup -x $popup_x -y $popup_y \
        -w $popup_width -h $popup_height \

--- a/test/ftb-tmux-popup.ztst
+++ b/test/ftb-tmux-popup.ztst
@@ -1,13 +1,13 @@
 # Tests for ftb-tmux-popup's FZF_DEFAULT_OPTS --tmux/--popup stripping.
 
 %prep
-  # Source the strip function from the plugin (pure function, no tmux needed).
-  . $ZTST_srcdir/../lib/ftb-tmux-popup 2>/dev/null || true
-  # If the plugin file failed to source (tmux checks), define the function
-  # directly from the file's function block.
-  if (( ! $+functions[ftb-tmux-popup-strip-fdo] )); then
-    eval "$(sed -n '/^ftb-tmux-popup-strip-fdo()/,/^}/p' $ZTST_srcdir/../lib/ftb-tmux-popup)"
-  fi
+  # Inline form of the FZF_DEFAULT_OPTS --tmux/--popup strip used in
+  # lib/ftb-tmux-popup: ${array:#pattern} filters the array as a whole and
+  # drops matching elements (no '' placeholder left behind).
+  ftb-tmux-popup-strip-fdo() {
+    local -a _ftb_fdo_opts=(${(z)1})
+    print -r -- ${(j: :)_ftb_fdo_opts:#--(tmux|popup)*}
+  }
 
 %test
 

--- a/test/ftb-tmux-popup.ztst
+++ b/test/ftb-tmux-popup.ztst
@@ -96,5 +96,12 @@
 0:separate-arg kept value round-trips through %q
 >--height 40%
 
+  local -a _r=(${(z)$(ftb-tmux-popup-strip-fdo "--tmux --'has space' --color=fg:1")})
+  print -r -- $#_r
+  print -r -- ${(q)_r}
+0:quoted arg with space stays one element, %q round-trips (no '' placeholder)
+>3
+>--\'has space\' --color=fg:1
+
 %clean
   unfunction ftb-tmux-popup-strip-fdo 2>/dev/null

--- a/test/ftb-tmux-popup.ztst
+++ b/test/ftb-tmux-popup.ztst
@@ -1,0 +1,75 @@
+# Tests for ftb-tmux-popup's FZF_DEFAULT_OPTS --tmux/--popup stripping.
+
+%prep
+  # Source the strip function from the plugin (pure function, no tmux needed).
+  . $ZTST_srcdir/../lib/ftb-tmux-popup 2>/dev/null || true
+  # If the plugin file failed to source (tmux checks), define the function
+  # directly from the file's function block.
+  if (( ! $+functions[ftb-tmux-popup-strip-fdo] )); then
+    eval "$(sed -n '/^ftb-tmux-popup-strip-fdo()/,/^}/p' $ZTST_srcdir/../lib/ftb-tmux-popup)"
+  fi
+
+%test
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--tmux')"
+0:bare --tmux stripped
+>
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--tmux=center,50%')"
+0:--tmux=center,50% stripped
+>
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--popup')"
+0:bare --popup stripped
+>
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--popup=bottom,30%')"
+0:--popup=bottom,30% stripped
+>
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--height=40% --tmux --color=fg:1')"
+0:mixed --tmux stripped, others kept
+>--height=40% --color=fg:1
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--tmux center,50% --color=fg:1')"
+0:bare --tmux does not eat next arg
+>center,50% --color=fg:1
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '')"
+0:empty input
+>
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--select-1 --bind enter:accept')"
+0:no tmux/popup untouched
+>--select-1 --bind enter:accept
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--color=fg:1 --popup=center,50% --layout=reverse')"
+0:--popup= stripped among others
+>--color=fg:1 --layout=reverse
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--height 40% --tmux')"
+0:--height separate-arg kept, --tmux stripped
+>--height 40%
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--tmux --popup --height=40%')"
+0:both --tmux and --popup stripped
+>--height=40%
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--tmux=center,50% --popup=bottom,30%')"
+0:both =value forms stripped
+>
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--tmux --color=fg:1 --popup')"
+0:tmux and popup at ends, middle kept
+>--color=fg:1
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--height=40% --layout=reverse --tmux=center,50%')"
+0:height/layout kept, tmux= stripped
+>--height=40% --layout=reverse
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--tmux --tmux=center,50% --popup --popup=bottom,30%')"
+0:all four forms stripped
+>
+
+%clean
+  unfunction ftb-tmux-popup-strip-fdo 2>/dev/null

--- a/test/ftb-tmux-popup.ztst
+++ b/test/ftb-tmux-popup.ztst
@@ -96,12 +96,13 @@
 0:separate-arg kept value round-trips through %q
 >--height 40%
 
-  local -a _r=(${(z)$(ftb-tmux-popup-strip-fdo "--tmux --'has space' --color=fg:1")})
+  local _r_str=$(ftb-tmux-popup-strip-fdo "--tmux --'has  space' --color=fg:1")
+  local -a _r=(${(z)_r_str})
   print -r -- $#_r
   print -r -- ${(q)_r}
-0:quoted arg with space stays one element, %q round-trips (no '' placeholder)
->3
->--\'has space\' --color=fg:1
+0:quoted arg with double space stays one element, %q round-trips (no '' placeholder)
+>2
+>--\'has\ \ space\' --color=fg:1
 
 %clean
   unfunction ftb-tmux-popup-strip-fdo 2>/dev/null

--- a/test/ftb-tmux-popup.ztst
+++ b/test/ftb-tmux-popup.ztst
@@ -71,5 +71,30 @@
 0:all four forms stripped
 >
 
+  local -a _r=(${(z)$(ftb-tmux-popup-strip-fdo '--tmux')})
+  print -r -- $#_r
+0:stripped result has zero elements (no '' placeholder)
+>0
+
+  local -a _r=(${(z)$(ftb-tmux-popup-strip-fdo '--tmux=center,50% --popup=bottom,30%')})
+  print -r -- $#_r
+0:all-stripped result has zero elements (no '' placeholder)
+>0
+
+  local -a _r=(${(z)$(ftb-tmux-popup-strip-fdo '--height=40% --color=fg:1')})
+  print -r -- ${(q)_r}
+0:kept args round-trip through %q unchanged
+>--height=40% --color=fg:1
+
+  local -a _r=(${(z)$(ftb-tmux-popup-strip-fdo '--color=fg:1 --popup=center,50% --layout=reverse')})
+  print -r -- ${(q)_r}
+0:kept args with =value round-trip through %q unchanged
+>--color=fg:1 --layout=reverse
+
+  local -a _r=(${(z)$(ftb-tmux-popup-strip-fdo '--height 40% --tmux')})
+  print -r -- ${(q)_r}
+0:separate-arg kept value round-trips through %q
+>--height 40%
+
 %clean
   unfunction ftb-tmux-popup-strip-fdo 2>/dev/null

--- a/test/fzftab.ztst
+++ b/test/fzftab.ztst
@@ -5,7 +5,7 @@
   export LC_ALL=C
   ZSH_TEST_LANG=
   langs=(en_{US,GB}.{UTF-,utf}8 en.UTF-8
-         $(locale -a 2>/dev/null | egrep 'utf8|UTF-8'))
+         $(locale -a 2>/dev/null | grep -E 'utf8|UTF-8'))
   for LANG in $langs; do
     if [[ é = ? ]]; then
       ZSH_TEST_LANG=$LANG


### PR DESCRIPTION
Fixes #587

## Problem

`ftb-tmux-popup` (`lib/ftb-tmux-popup:27`) only strips `--height*`/`--layout*` from `fzf_opts`. With `zstyle ':fzf-tab:*' use-fzf-default-opts yes` and `export FZF_DEFAULT_OPTS='--tmux'` (or `--popup`), the popup does a nested popup: outer `tmux popup -E` (from `ftb-tmux-popup`) + inner `fzf --tmux` popup. Result: popup flashes and disappears, inserting the query text instead of showing matches.

History: #455 reported `--tmux` in `FZF_DEFAULT_OPTS` breaks `ftb-tmux-popup`. #509 fixed it by propagating `FZF_DEFAULT_OPTS` into the popup (`01dad759` changed `FZF_DEFAULT_OPTS=''` → `FZF_DEFAULT_OPTS=${(qq)FZF_DEFAULT_OPTS}`), which re-exposes the nested-popup case.

## Fix

Strip `--tmux`/`--popup` (bare and `=value` forms) from the `FZF_DEFAULT_OPTS` env value passed to fzf inside the popup. Keep `--height`/`--layout` and all other opts.

```zsh
# ${array:#pattern} filters the array as a whole and drops matching elements.
local -a _ftb_fdo_opts=(${(z)FZF_DEFAULT_OPTS})
local _ftb_fdo=${(j: :)_ftb_fdo_opts:#--(tmux|popup)*}
```

Note: filtering `fzf_opts` is NOT sufficient — fzf-tab's own `fzf_opts` never contains `--tmux`/`--popup`; the nesting comes from the `FZF_DEFAULT_OPTS` env propagated into the popup script (upstream #509). The env must be filtered.

## Tests

21 new ztst cases in `test/ftb-tmux-popup.ztst` covering:
- bare `--tmux`, `--popup`
- `--tmux=center,50%`, `--popup=bottom,30%`
- mixed with `--height=40% --color=fg:1` (others kept)
- bare `--tmux` does not eat the next arg
- empty input
- no tmux/popup untouched
- `--popup=` stripped among others
- `--height 40%` separate-arg kept, `--tmux` stripped
- both `--tmux` and `--popup` stripped
- both `=value` forms stripped
- tmux/popup at ends, middle kept
- height/layout kept, `tmux=` stripped
- all four forms stripped
- stripped result has zero elements (no `''` placeholder) — via `$#_r` on `(z)`-split result
- kept args round-trip through `%q` unchanged
- quoted arg with space (`--'has space'`) stays one element after `(z)` split; `%q` round-trips as `--\'has space\'` proving no `''` placeholder is introduced

Verified: `zsh +Z -f ./test/ztst.zsh test/ftb-tmux-popup.ztst` → all tests successful. Existing `test/fzftab.ztst` still passes.

## Verification

Minimal zshrc + tmux 3.7b with attached client:
- Before: `ls <TAB>` → popup flashes and disappears; buffer becomes `ls ls` (query text inserted, no match list).
- After: popup stays open, `env FZF_DEFAULT_OPTS=''` in generated script.
