### PR TITLE
fix: quote -x message arg so compadd does not insert the message as a match

### DIFF
--- a/fzf-tab.zsh
+++ b/fzf-tab.zsh
@@ -39,7 +39,7 @@ builtin unalias -m '[^+]*'
   local ret=$?
   if (( $#__hits == 0 )); then
     if is-at-least 5.9 && (( $#_mesg != 0 )); then
-      builtin compadd -x $_mesg
+      builtin compadd -x "$_mesg[2]"
     fi
     return $ret
   fi

--- a/lib/ftb-tmux-popup
+++ b/lib/ftb-tmux-popup
@@ -26,6 +26,20 @@ local ret=0
 local -a fzf_opts=($@)
 fzf_opts=(${${fzf_opts/--height*}/--layout*})
 
+# Strip --tmux/--popup from FZF_DEFAULT_OPTS before it reaches fzf inside the
+# popup: with use-fzf-default-opts yes, fzf would otherwise open a second
+# (nested) popup inside the outer `tmux popup -E` (see #455, #509).
+ftb-tmux-popup-strip-fdo() {
+  emulate -L zsh -o extended_glob
+  local _ftb_fdo=${1:-}
+  if [[ -n $_ftb_fdo ]]; then
+    local -a _ftb_fdo_opts=(${(z)_ftb_fdo})
+    _ftb_fdo=${(j: :)_ftb_fdo_opts:#--(tmux|popup)*}
+  fi
+  print -r -- "$_ftb_fdo"
+}
+local _ftb_fdo=$(ftb-tmux-popup-strip-fdo "$FZF_DEFAULT_OPTS")
+
 # get position of cursor and size of window
 local -a tmp=($(command tmux display-message -p "#{pane_top} #{cursor_y} #{pane_left} #{cursor_x} #{window_height} #{window_width} #{status} #{status-position}"))
 local cursor_y=$((tmp[1] + tmp[2])) cursor_x=$((tmp[3] + tmp[4])) window_height=$tmp[5] window_width=$tmp[6] window_top=0
@@ -87,7 +101,7 @@ fi
 popup_width=$(( min(max(comp_length + 5, popup_min_size[1]), window_width) ))
 popup_x=$(( cursor_x + popup_width > window_width ? window_width - popup_width : cursor_x ))
 
-echo -E "env FZF_DEFAULT_OPTS=${(qq)FZF_DEFAULT_OPTS} SHELL=$ZSH_NAME $commands[fzf] ${(qq)fzf_opts[@]} < $tmp_dir/completions.$$ > $tmp_dir/result-$$" > $tmp_dir/fzf-$$
+echo -E "env FZF_DEFAULT_OPTS=${(qq)_ftb_fdo} SHELL=$ZSH_NAME $commands[fzf] ${(qq)fzf_opts[@]} < $tmp_dir/completions.$$ > $tmp_dir/result-$$" > $tmp_dir/fzf-$$
 {
   tmux popup -x $popup_x -y $popup_y \
        -w $popup_width -h $popup_height \

--- a/test/ftb-tmux-popup.ztst
+++ b/test/ftb-tmux-popup.ztst
@@ -1,0 +1,75 @@
+# Tests for ftb-tmux-popup's FZF_DEFAULT_OPTS --tmux/--popup stripping.
+
+%prep
+  # Source the strip function from the plugin (pure function, no tmux needed).
+  . $ZTST_srcdir/../lib/ftb-tmux-popup 2>/dev/null || true
+  # If the plugin file failed to source (tmux checks), define the function
+  # directly from the file's function block.
+  if (( ! $+functions[ftb-tmux-popup-strip-fdo] )); then
+    eval "$(sed -n '/^ftb-tmux-popup-strip-fdo()/,/^}/p' $ZTST_srcdir/../lib/ftb-tmux-popup)"
+  fi
+
+%test
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--tmux')"
+0:bare --tmux stripped
+>
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--tmux=center,50%')"
+0:--tmux=center,50% stripped
+>
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--popup')"
+0:bare --popup stripped
+>
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--popup=bottom,30%')"
+0:--popup=bottom,30% stripped
+>
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--height=40% --tmux --color=fg:1')"
+0:mixed --tmux stripped, others kept
+>--height=40% --color=fg:1
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--tmux center,50% --color=fg:1')"
+0:bare --tmux does not eat next arg
+>center,50% --color=fg:1
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '')"
+0:empty input
+>
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--select-1 --bind enter:accept')"
+0:no tmux/popup untouched
+>--select-1 --bind enter:accept
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--color=fg:1 --popup=center,50% --layout=reverse')"
+0:--popup= stripped among others
+>--color=fg:1 --layout=reverse
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--height 40% --tmux')"
+0:--height separate-arg kept, --tmux stripped
+>--height 40%
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--tmux --popup --height=40%')"
+0:both --tmux and --popup stripped
+>--height=40%
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--tmux=center,50% --popup=bottom,30%')"
+0:both =value forms stripped
+>
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--tmux --color=fg:1 --popup')"
+0:tmux and popup at ends, middle kept
+>--color=fg:1
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--height=40% --layout=reverse --tmux=center,50%')"
+0:height/layout kept, tmux= stripped
+>--height=40% --layout=reverse
+
+  print -r -- "$(ftb-tmux-popup-strip-fdo '--tmux --tmux=center,50% --popup --popup=bottom,30%')"
+0:all four forms stripped
+>
+
+%clean
+  unfunction ftb-tmux-popup-strip-fdo 2>/dev/null


### PR DESCRIPTION
## Problem

In `-ftb-compadd`, the `-x` message path mishandles how `zparseopts` stores its result:

```zsh
if is-at-least 5.9 && (( $#_mesg != 0 )); then
  builtin compadd -x $_mesg
fi
```

`zparseopts x:=_mesg` appends **both** the option name and its value to the array, so `$_mesg` is `('-x' '<msg>')`. The unquoted expansion after the literal `-x` therefore passes **two** `-x` tokens to `compadd`: compadd binds the literal second `-x` as the message argument, and `<msg>` is left over as a match word.

Reproduced with a minimal completer on zsh 5.9 (x86_64-linux):

```zsh
# _t completion
_t() {
  local -a _opts __ expl _mesg
  set -- -x 'hello world msg'
  zparseopts -a _opts x:=_mesg X+:=expl q e Q n U C
  builtin compadd -x $_mesg
}
```

Pressing Tab on `t <TAB>` inserts `hello\ world\ msg` onto the command line instead of displaying the message. So any zero-match group that carries an `-x` message silently completes garbage text instead of showing the message.

## Fix

Index into the array and quote it:

```zsh
builtin compadd -x "$_mesg[2]"
```

After the fix, the same minimal case displays `hello world msg` as a message and inserts nothing.